### PR TITLE
feat(security): Enable force-ssl on heroku/ production

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/common.py
@@ -55,6 +55,8 @@ class Common(Configuration):
     # MIDDLEWARE CONFIGURATION
     # Note: Order in which they are added are important
     MIDDLEWARE_CLASSES = (
+        # Make sure djangosecure.middleware.SecurityMiddleware is the first middleware class listed
+        'djangosecure.middleware.SecurityMiddleware',
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.common.CommonMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/production.py
@@ -10,6 +10,10 @@ from .common import Common
 
 class Production(Common):
 
+    # This ensures that Django will be able to detect a secure connection
+    # properly on Heroku.
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
     # INSTALLED_APPS
     INSTALLED_APPS = Common.INSTALLED_APPS
     # END INSTALLED_APPS


### PR DESCRIPTION
Heroku provides piggyback SSL by default, which 
enables you to have urls like https://yourapp.herokuapp.com/ :blush:. 
So let’s have https everywhere.
https://blog.heroku.com/archives/2012/5/3/announcing_better_ssl_for_your_app

![ssl all the things](https://github.com/rdegges/django-sslify/raw/master/assets/ssl_all_the_things.jpg)
