### PR TITLE
feat(CI): add travis file

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,6 +1,7 @@
 {
     "repo_name": "repo-name"
-    , "repo_url": "git@github.com:Fueled/repo_name.git"
+    , "github_username": "Fueled"
+    , "github_reponame": ""
     , "site_name": "My Project"
     , "site_description": "add a short project description here"
     , "timezone": "UTC"

--- a/{{cookiecutter.repo_name}}/.travis.yml
+++ b/{{cookiecutter.repo_name}}/.travis.yml
@@ -1,0 +1,29 @@
+language: python
+python:
+- '2.7'
+install: pip install -q -r configurations/pip/development.txt
+before_script: flake8
+script: python {{ cookiecutter.repo_name }}/manage.py test
+notifications:
+  hipchat:
+    rooms:
+      # travis encrypt api_token@room_name --add notifications.hipchat.rooms
+      secure: <add_room_key_here>
+    template:
+    - '%{repository}#%{build_number} (%{branch} - %{commit} : %{author}): %{message} (<a href="%{build_url}">Details</a>/<a href="%{compare_url}">Change view</a>)'
+    format: html
+deploy:
+  provider: heroku
+  buildpack: python
+  api_key:
+    # travis encrypt $(heroku auth:token) --add deploy.api_key
+    secure: <add_heroku_auth_token_here>
+  app:
+    master: {{ cookiecutter.repo_name }}-dev
+    qa: {{ cookiecutter.repo_name }}-qa
+    prod: {{ cookiecutter.repo_name }}-prod
+  on:
+    repo: {{ cookiecutter.github_username }}/{{ cookiecutter.github_reponame }}
+  run:
+    - "python {{ cookiecutter.repo_name }}/manage.py migrate
+    - "python {{ cookiecutter.repo_name }}/manage.py collectstatic

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -27,22 +27,22 @@ First make sure to create and activate a virtualenv, then open a terminal at the
 
 1. Clone this repo to your local development machine.
 
-	```
-    git clone {{ cookiecutter.repo_url }} && cd {{ cookiecutter.repo_name }}
+    ```
+    git clone git@github.com:{{ cookiecutter.github_username }}/{{ cookiecutter.github_reponame }}.git && cd {{ cookiecutter.github_reponame }}
     ```
 
 2. Install `fab` command
 
-	```
+    ```
     sudo pip install fabric
     ```
 
 3. Setup the required environment variables
 
-	```
-	fab config:set,DJANGO_DATABASE_URL,[value]
-	```
-	* URL Format Ref: https://github.com/kennethreitz/dj-database-url#url-schema
+    ```
+    fab config:set,DJANGO_DATABASE_URL,[value]
+    ```
+    * URL Format Ref: https://github.com/kennethreitz/dj-database-url#url-schema
 
 4. From inside the project repo, run `fab init`, it will ask your system password.
 

--- a/{{cookiecutter.repo_name}}/configurations/ansible/vars.yml
+++ b/{{cookiecutter.repo_name}}/configurations/ansible/vars.yml
@@ -1,6 +1,6 @@
 ---
 project_name: {{ cookiecutter.repo_name }}
-project_repo_url: {{ cookiecutter.repo_url }}
+project_repo_url: git@github.com:{{ cookiecutter.github_username }}/{{ cookiecutter.github_reponame }}.git
 project_repo_remote: origin
 domain_name: {{ cookiecutter.domain_name }}
 repo_version: master

--- a/{{cookiecutter.repo_name}}/configurations/pip/development.txt
+++ b/{{cookiecutter.repo_name}}/configurations/pip/development.txt
@@ -5,3 +5,6 @@ django-debug-toolbar==1.2.1
 
 # A better python shell
 ipython==2.2.0
+
+# Testing
+flake8

--- a/{{cookiecutter.repo_name}}/package.json
+++ b/{{cookiecutter.repo_name}}/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "{{cookiecutter.repo_name}}",
+  "name": "{{ cookiecutter.repo_name }}",
   "version": "{{ cookiecutter.version }}",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
- add standard travis file with deployment to heroku, for aws or other things modify it in project 
  or make use `{% if cookiecutter.aws %}` thing later.
- now we use github_username and github_reponame, github is our standard git host. It makes 
  it easy to populates settings in tavis.

@Fueled/backend-team up for review. I'll do rebase once it's looks all good. 
