### PR TITLE
feat(docs): generate model graph as part of doc build process

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/backend/db.md
+++ b/{{cookiecutter.repo_name}}/docs/backend/db.md
@@ -1,7 +1,13 @@
+<style>
+    /* make the main container full-size for better viewing */
+    .col-md-3 {display: none;}
+    .col-md-9 {width: 100%;}
+</style>
+
 This project usages `postgres` as the primary persistent database.
 
-Below is the internal relational database representation of {{ cookiecutter.project_name }} backend. ([view original][database_diagram])
+Below is the internal representationf of all the models used in this project. ([View enlarged][database_diagram])
 
 ![database diagram][database_diagram]
 
-[database_diagram]: (img/{{ cookiecutter.repo_name }}_dbschema.svg)
+[database_diagram]: img/graph_model.svg

--- a/{{cookiecutter.repo_name}}/fabfile.py
+++ b/{{cookiecutter.repo_name}}/fabfile.py
@@ -65,14 +65,25 @@ def install_deps(file=env.requirements_file):
 
 
 def serve_docs(address='127.0.0.1', port='8001'):
+<<<<<<< HEAD
     '''Start a local server to view documentation changes.'''
     with lcd(ROOT_DIR):
+=======
+    with lcd(here):
+        create_graph_models()
+>>>>>>> feat(docs): generate model graph as part of doc build process
         local('mkdocs serve --dev-addr=%s:%s' % (address, port))
 
 
 def deploy_docs():
+<<<<<<< HEAD
     with lcd(ROOT_DIR):
         local('mkdocs build')
+=======
+    with lcd(here):
+        create_graph_models()
+        local('mkdocs build --clean')
+>>>>>>> feat(docs): generate model graph as part of doc build process
         local('ghp-import -m "Documentaion updated." -p _docs_html')
         local('rm -rf _docs_html')
 
@@ -154,6 +165,23 @@ def manage(cmd, venv=True):
         local('python manage.py %s' % cmd)
 
 
+<<<<<<< HEAD
+=======
+def create_graph_models():
+    '''Generates graph of all the models in this project.'''
+    graph_model_output = join(env.docs_dir, 'img/graph_model.svg')
+    manage("graph_models -a -g -o %s" % graph_model_output)
+
+
+def test(options='--ipdb'):
+    '''Run tests locally.'''
+    with virtualenv():
+        local('flake8 .')
+        local("coverage run --source=onydo --omit='%s' -m py.test %s" % (env.coverage_omit, options))
+        local("coverage report")
+
+
+>>>>>>> feat(docs): generate model graph as part of doc build process
 @_contextmanager
 def virtualenv():
     '''Activates virtualenv context for other commands to run inside it

--- a/{{cookiecutter.repo_name}}/requirements/development.txt
+++ b/{{cookiecutter.repo_name}}/requirements/development.txt
@@ -3,6 +3,7 @@
 # documentation
 # -------------------------------------
 mkdocs==0.10
+pygraphviz==1.2
 ghp-import==0.4.1
 
 # Debugging


### PR DESCRIPTION
makes use of `manage.py graph_model` from `django-extensions` package
to create a grouped visualization of all the models in the project.

This affects`fab serve_docs` and `fab deploy_docs` command.
