### PR TITLE
feat(cache): replace redis as cache backend

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/backend/server_config.md
+++ b/{{cookiecutter.repo_name}}/docs/backend/server_config.md
@@ -11,7 +11,7 @@ heroku create <heroku-app-name> --buildpack https://github.com/heroku/heroku-bui
 heroku addons:add heroku-postgresql:dev --app=<heroku-app-name>
 heroku addons:add pgbackups:auto-month --app=<heroku-app-name>
 heroku addons:add sendgrid:starter --app=<heroku-app-name>
-heroku addons:add memcachier:dev --app=<heroku-app-name>
+heroku addons:add redistogo --app=<heroku-app-name>
 heroku pg:promote DATABASE_URL --app=<heroku-app-name>
 heroku config:set DJANGO_CONFIGURATION=Production \
 DJANGO_SECRET_KEY=`openssl rand -base64 32` \

--- a/{{cookiecutter.repo_name}}/requirements/common.txt
+++ b/{{cookiecutter.repo_name}}/requirements/common.txt
@@ -12,7 +12,6 @@ pytz==2014.10
 django-configurations==0.8
 django-sites==0.8
 django-secure==1.0.1
-django-cache-url==0.8.0
 dj-database-url==0.3.0
 python-dotenv==0.1.0
 

--- a/{{cookiecutter.repo_name}}/requirements/production.txt
+++ b/{{cookiecutter.repo_name}}/requirements/production.txt
@@ -7,7 +7,7 @@
 django-storages==1.1.8
 Collectfast==0.2.1
 boto==2.34.0
-pylibmc==1.3.0
 gevent==1.0.1
 gunicorn==19.1.1
-django-heroku-memcacheify
+hiredis==0.1.5
+django-redis-cache==0.13.0


### PR DESCRIPTION
Why - we already use redis for bunch of over services like celery and it
has less OS level dependecy like pylibmc

Use hiredis parser for faster serialization/deserialization.

@Fueled/backend-team ready for review!
