### PR TITLE
chore(templating): initialize the repo with version 0.0.0

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,7 @@
     , "project_description": "add a short project description here"
     , "timezone": "UTC"
     , "django_admin_email": "noreply@example.com"
-    , "version": "0.1.0"
+    , "version": "0.0.0"
     , "celery": "n"
     , "newrelic" : "y"
 }


### PR DESCRIPTION
- 0.0.0 indicates a non-setup project, as manual setup might be required
  depending upon the project requirements.
- when the initial setup is complete use, and we have `dev` environment
  up and running with test and travis deployment, we are going to use
  `bumpversion minor` to make a release 0.1.0 and then continue using
  Semantic Versioning 2.0.0[1] for futher releases.
- `bumpversion` is a cli tool installed from `development.txt` [2]

[1] http://semver.org/spec/v2.0.0.html
[2] https://github.com/peritus/bumpversion
