### PR TITLE
fix(bumpversion): update config to include release status

### DIFF
--- a/{{cookiecutter.repo_name}}/.bumpversion.cfg
+++ b/{{cookiecutter.repo_name}}/.bumpversion.cfg
@@ -2,6 +2,10 @@
 current_version = {{ cookiecutter.version }}
 commit = True
 tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
+serialize =
+    {major}.{minor}.{patch}-{release}
+    {major}.{minor}.{patch}
 
 [bumpversion:file:{{ cookiecutter.repo_name }}/__init__.py]
 
@@ -12,3 +16,9 @@ tag = True
 [bumpversion:file:package.json]
 
 [bumpversion:file:README.md]
+
+[bumpversion:part:release]
+optional_value = gamma
+values =
+    dev
+    gamma

--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -1,7 +1,7 @@
 {{ cookiecutter.project_name }}
 ==============================
 
-![version {{ cookiecutter.version }}](http://img.shields.io/badge/Version-{{ cookiecutter.version }}-blue.svg)
+__Version:__ {{ cookiecutter.version }}
 
 {{ cookiecutter.project_description }}
 
@@ -39,6 +39,21 @@ The deployment are managed via travis, but for the first time you'll need to set
 
 Check out detailed server setup instruction [here](docs/backend/server_config.md).
 
+## How to release {{ cookiecutter.project_name }}
+
+Execute the following commands:
+
+```
+git checkout master
+fab test
+bumpversion release
+bumpversion --no-tag patch # 'patch' can be replaced with 'minor' or 'major'
+git push origin master
+git push origin master --tags
+git checkout qa
+git rebase master
+git push origin qa
+```
 
 ## Contributing
 

--- a/{{cookiecutter.repo_name}}/docs/index.md
+++ b/{{cookiecutter.repo_name}}/docs/index.md
@@ -1,8 +1,6 @@
 # {{ cookiecutter.project_name }} Documentation
 
-<img src="http://img.shields.io/badge/Version-{{ cookiecutter.version }}-blue.svg" alt="Version {{ cookiecutter.version }}" style="margin: 0">
-
-{{ cookiecutter.project_description }}
+__Version:__ {{ cookiecutter.version }}
 
 ## API
 


### PR DESCRIPTION
- add documentation for tagging releasing project using bumpversion
- remove generate `.svg` for version as they are not very friendly with
  `-` in the version name e.g. `0.1.0-dev`

see: https://github.com/peritus/bumpversion
