### PR TITLE
feat(docs/mkdocs): add 'urlize' markdown extension

### DIFF
--- a/{{cookiecutter.repo_name}}/mkdocs.yml
+++ b/{{cookiecutter.repo_name}}/mkdocs.yml
@@ -22,3 +22,5 @@ copyright: Copyright &copy; 2015, <a href=http://fueled.com>Fueled</a>.
 
 # directory to output HTML build
 site_dir: _docs_html
+
+markdown_extensions: [urlize]

--- a/{{cookiecutter.repo_name}}/requirements/development.txt
+++ b/{{cookiecutter.repo_name}}/requirements/development.txt
@@ -2,6 +2,7 @@
 
 # Documentation
 # -------------------------------------
+https://github.com/r0wb0t/markdown-urlize/archive/8bf9bd75cf61ba255bd91a9e808add925d95412e.zip
 https://github.com/tomchristie/mkdocs/archive/master.zip
 pygraphviz==1.3rc2
 


### PR DESCRIPTION
To convert the bare url in markdown text to clickable link in html,
like it's done on github.

see: https://github.com/r0wb0t/markdown-urlize
