### PR TITLE
fix(settings): update order of 'collectfast' in Installed apps.

### DIFF
--- a/{{cookiecutter.repo_name}}/settings/production.py
+++ b/{{cookiecutter.repo_name}}/settings/production.py
@@ -80,7 +80,8 @@ class Production(Common):
 
     # see: https://github.com/antonagestam/collectfast
     AWS_PRELOAD_METADATA = True
-    INSTALLED_APPS += ("collectfast", )
+    # For Django 1.7+, 'collectfast' should come before 'django.contrib.staticfiles'
+    INSTALLED_APPS = ("collectfast", ) + INSTALLED_APPS
 
     # AWS cache settings, don't change unless you know what you're doing:
     AWS_EXPIREY = 60 * 60 * 24 * 7


### PR DESCRIPTION
- Why: https://github.com/pydanny/cookiecutter-django/pull/199
- Lucky due to class based inheritence we can change the order easily.
- No side effects.
