### PR TITLE
feat(drf/throttling): add basic throttling for anonymous requests 10000/day/IP

### DIFF
--- a/{{cookiecutter.repo_name}}/docs/api/overview.md
+++ b/{{cookiecutter.repo_name}}/docs/api/overview.md
@@ -45,6 +45,10 @@ Requests that return multiple items will be paginated to 30 items by default. Yo
 
 Note that page numbering is 1-based and that omitting the `?page` parameter will return the first page.
 
+# Rate Limit
+
+All the unauthorized urls have a rate limit of 10,000 requests/day/IP. After exceeding the limit, you'll get `HTTP TOO MANY REQUESTS` with status code `429`. When this happens you'll also receive `X-Throttle-Wait-Seconds: <time_in_sec>` header in response header.
+
 
 ## Authorization
 

--- a/{{cookiecutter.repo_name}}/settings/common.py
+++ b/{{cookiecutter.repo_name}}/settings/common.py
@@ -92,6 +92,12 @@ class Common(Configuration):
         'DEFAULT_PERMISSION_CLASSES': [
             'rest_framework.permissions.IsAuthenticated',
         ],
+        'DEFAULT_THROTTLE_CLASSES': (
+            'rest_framework.throttling.AnonRateThrottle',
+        ),
+        'DEFAULT_THROTTLE_RATES': {
+            'anon': '10000/day',
+        },
         'DEFAULT_AUTHENTICATION_CLASSES': (
             'rest_framework.authentication.BasicAuthentication',
 


### PR DESCRIPTION
This protects the unauthorized requests like signup and forgot password
from D-Dos and brute force attacks upto a level.

See: http://www.django-rest-framework.org/api-guide/throttling/
