### PR TITLE
feat(docs): add support for UML: sequence diagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 ### Added
+- Add support for UML: [sequence diagrams](http://en.wikipedia.org/wiki/Sequence_diagram)
 - Add locale_path to settings, to help facilitate translation when required
 - Removed celery settings, as it's hardly used.
 - Add api versioning support via Accept headers (#52)

--- a/{{cookiecutter.repo_name}}/docs/backend/server_config.md
+++ b/{{cookiecutter.repo_name}}/docs/backend/server_config.md
@@ -1,5 +1,19 @@
 # Server Architecture and configurations
 
+```sequence
+title: Client Server Interactions
+iOS/\nClient->Web\nServer: API Request
+Web\nServer-->Redis: Cache
+Redis-->Web\nServer: 
+Web\nServer->Postgres: Persistent Storage
+Postgres->Web\nServer: 
+Web\nServer-->Redis: Update cache
+Web\nServer-->SMTP: Enqueue emails
+Web\nServer->iOS/\nClient: API Response
+SMTP->iOS/\nClient: Email
+Note over Web\nServer: Django Framework
+```
+
 # Third Party Services
 
 Following third-party services are required in order to setup/deploy this project successfully.
@@ -67,3 +81,22 @@ heroku open --app=<heroku-app-name>
 ### AWS/EC2
 
 For deploying on aws you need to configure all the addons provided and use python-dotenv to store and read enironment variables. You should using the ansible script in `provisioner` to handle the configuration and deployment on remote servers.
+
+<!-- Support for UML: Sequence diagrams 
+See: https://bramp.github.io/js-sequence-diagrams 
+Usuages: 
+Add a code block with "```" with "sequence" as language marker, then write the arrow based syntax.
+Example:
+
+```sequence
+a->b: A interacts with B
+b->a: B responds
+```
+-->
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+<script src="//bramp.github.io/js-sequence-diagrams/raphael-min.js"></script>
+<script src="//bramp.github.io/js-sequence-diagrams/underscore-min.js"></script>
+<script src="//bramp.github.io/js-sequence-diagrams/sequence-diagram-min.js"></script>
+<script>
+    $('.sequence').sequenceDiagram({"theme": "simple"}).parent().removeClass("prettyprint").css({"background-color": "#fff", "text-align": "center"});
+</script>


### PR DESCRIPTION
Adds support for js based rendered sequence diagram to explain the
server stacks and how/when they interact with each other.

This eliminates the use of any third party application to generate the
diagram and it's much faster to write and update.

**How to use:**
In markdown, write a code block with language as `sequence` following
the syntax from http://bramp.github.io/js-sequence-diagrams.

**Example**

<pre>
```sequence
a->b: A interacts with B
b->a: B responds
```
</pre>


will render to representation of the form:

![a](https://www.dropbox.com/s/hxhp3jqegkgkr5g/Screenshot%202015-04-14%2018.49.43.png?dl=1)

**References**:
- http://en.wikipedia.org/wiki/Sequence_diagram
- http://bramp.github.io/js-sequence-diagrams

closes #48
