### PR TITLE
Remove support for any specific css/js framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add `iSort` configuration (#42)
 
 ### Changed
+- Remove support for `Foundation`
 - Swap `django-storages` with `django-storages-redux`
 - Add test for cookiecutter renderning (#34)
 - upgrade to django-rest-framwork-3.0

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/pages/templates/pages/about.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/pages/templates/pages/about.html
@@ -1,8 +1,7 @@
 {% raw %}{% extends 'pages/base.html' %}
 
 {% block content %}
-    <h1>About</h1>
     <p>
-        comming soon!!
+        About page comming soon!!
     </p>
 {% endblock content %}{% endraw %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/pages/templates/pages/home.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/pages/templates/pages/home.html
@@ -1,8 +1,7 @@
 {% raw %}{% extends 'pages/base.html' %}
 
 {% block content %}
-    <h1>About</h1>
     <p>
-        coming soon!!
+        Homepage coming soon!!
     </p>
 {% endblock content %}{% endraw %}

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.html
@@ -15,7 +15,6 @@
     <![endif]-->
 
     {% block css %}
-    <link href="//cdnjs.cloudflare.com/ajax/libs/foundation/5.4.7/css/foundation.css" rel="stylesheet">
     <link href="{% static 'css/project.css' %}" rel="stylesheet">
     {% endblock css %}
   </head>
@@ -26,63 +25,21 @@
     <![endif]-->
 
     {% block header %}
-    <header>
-        <nav class="top-bar" data-topbar>
-            <ul class="title-area">
-                <li class="name">
-                  <h1><a href="#">{% endraw %}{{ cookiecutter.project_name }}{% raw %}</a></h1>
-                </li>
-                <li class="toggle-topbar menu-icon"><a href="#">Menu</a></li>
-            </ul> {# .title-area #}
-
-            <section class="top-bar-section">
-                <!-- Right Nav Section -->
-                <ul class="right">
-                  <li class="active"><a href="#">Right Button Active</a></li>
-                  <li class="has-dropdown">
-                    <a href="#">Right Button with Dropdown</a>
-                    <ul class="dropdown">
-                      <li><a href="#">First link in dropdown</a></li>
-                    </ul>
-                  </li>
-                </ul>
-
-                <!-- Left Nav Section -->
-                <ul class="left">
-                  <li><a href="#">Left Nav Button</a></li>
-                </ul>
-            </section> {# .top-bar-section #}
-        </nav> {# .top-bar #}
-    </header>
+      <h1>{{ cookiecutter.project_name }}.</h1>
     {% endblock header %}
 
-    {% if messages %}
-        {% for message in messages %}
-            <div data-alert class="alert-box {% if message.tags %}{{ message.tags }}"{% endif %}>
-            {{ message }} <a href="#" class="close">&times;</a>
-            </div>
-        {% endfor %}
-    {% endif %}
-
     {% block content %}
-        <p>Coming soon!</p>
+    <p>Coming soon!</p>
     {% endblock content %}
 
     </div> <!-- /container -->
-
-    {% block modal %}{% endblock modal %}
 
     <!-- Le javascript
     ================================================== -->
     {# Placed at the end of the document so the pages load faster #}
     {% block js %}
       <!-- Latest JQuery -->
-      <script src="//cdnjs.cloudflare.com/ajax/libs/fastclick/1.0.3/fastclick.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/5.4.7/js/vendor/jquery.js"></script>
-
-      {# see: http://cdnjs.com/libraries/foundation/ #}
-      <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/5.4.7/js/foundation.min.js"></script>
-      <script src="//cdnjs.cloudflare.com/ajax/libs/foundation/5.4.7/js/foundation/foundation.alert.js"></script>
+      <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 
       <!-- Your stuff: Third-party javascript libraries go here -->
 

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/humans.txt
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/humans.txt
@@ -14,5 +14,5 @@ Name: name or url
 
 Last update: YYYY/MM/DD
 Standards: HTML5, CSS3,..
-Components: Foundation, jQuery,...
+Components: jQuery,...
 Software: Software used for the development


### PR DESCRIPTION
**Why**
- Different people have different opinion for using css framework.
  For that matter, Fueled frontend team doesn't use any specific
  framework.
- The idea is to keep it simple, so the base content is kept as per
  html5boilerplate[1]
- The SASS support is still there, but instead of grunt django-compressor
  might be a good solution to handle static assests.

**References**

[1] https://github.com/h5bp/html5-boilerplate/blob/master/src/index.html

closes #47
