### PR TITLE
refractor(root_files): route `robots.txt`, `humans.txt`, etc in a better way

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Project template for django based projects, optimized for making REST API with d
 - Use [mkdocs] for project documentation.
 - Uses [py.test] as test runner.
 - `travis.yml` for running isolated tests and deployments to dev/qa/prod environment on Heroku from git branches.
-- Only tested and stable third-party libraries are added.
+- Only tested and stable third-party libraries are added
+- HTML5 boilerplate
+- robots.txt and humans.txt configured
 
 [mkdocs]: http://www.mkdocs.org/
 [12factor]: http://12factor.net

--- a/{{cookiecutter.repo_name}}/tests/integration/test_root_txt_files.py
+++ b/{{cookiecutter.repo_name}}/tests/integration/test_root_txt_files.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+# Third Party Stuff
+from django.core.urlresolvers import reverse
+
+
+def test_home_file(client):
+    files = ['robots.txt', 'humans.txt']
+    for filename in files:
+        url = reverse('root-txt-files', kwargs={'filename': filename})
+        response = client.get(url)
+        assert response.status_code == 200
+        assert response['Content-Type'] == 'text/plain'

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base/views.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/base/views.py
@@ -8,6 +8,7 @@ import sys
 from django import http
 from django.conf import settings
 from django.views.defaults import server_error as dj_server_error
+from django.shortcuts import render
 
 
 def server_error(request, *args, **kwargs):
@@ -25,3 +26,7 @@ def server_error(request, *args, **kwargs):
             }), content_type="application/json")
 
     return dj_server_error(request, *args, **kwargs)
+
+
+def root_txt_files(request, filename):
+    return render(request, filename, {}, content_type="text/plain")

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/pages/urls.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/pages/urls.py
@@ -18,8 +18,4 @@ urlpatterns = [
         TemplateView.as_view(template_name='pages/home.html'), name="home"),
     url(r'^about/$',
         TemplateView.as_view(template_name='pages/about.html'), name="about"),
-    url(r'^robots\.txt$',
-        TemplateView.as_view(template_name='robots.txt', content_type='text/plain'), name='robots'),
-    url(r'^humans\.txt$',
-        TemplateView.as_view(template_name='humans.txt', content_type='text/plain'), name='humans'),
 ]

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/urls.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/urls.py
@@ -18,6 +18,9 @@ handler500 = "{{ cookiecutter.repo_name }}.base.views.server_error"
 
 urlpatterns = [
 
+    url(r'^(?P<filename>(robots.txt)|(humans.txt))$',
+        "{{ cookiecutter.repo_name }}.base.views.root_txt_files", name='root-txt-files'),
+
     # Rest API
     url(r'^api/', include(router.urls)),
 


### PR DESCRIPTION
- use function based views for expandability and easy testing
- these route now lives independent of pages, at root url conf
