### PR TITLE
fix(fabfile): activate virtualenv before executing docs related fab commands

### DIFF
--- a/{{cookiecutter.repo_name}}/fabfile.py
+++ b/{{cookiecutter.repo_name}}/fabfile.py
@@ -66,12 +66,12 @@ def install_deps(file=env.requirements_file):
 
 def serve_docs(options=''):
     '''Start a local server to view documentation changes.'''
-    with lcd(ROOT_DIR):
+    with lcd(ROOT_DIR) and virtualenv():
         local('mkdocs serve {}'.format(options))
 
 
 def deploy_docs():
-    with lcd(ROOT_DIR):
+    with lcd(ROOT_DIR) and virtualenv():
         local('mkdocs gh-deploy')
         local('rm -rf _docs_html')
 


### PR DESCRIPTION
mkdocs is a python package installed in virtualenv.

Therefore, we should follow other fab commands like serve, test and activate virtualenv before running serve_docs, and deploy_docs.
