### PR TITLE
chore(deps): update requirements to latest stable

### DIFF
--- a/{{cookiecutter.repo_name}}/requirements/common.txt
+++ b/{{cookiecutter.repo_name}}/requirements/common.txt
@@ -1,7 +1,7 @@
 # Core Stuff
 # -------------------------------------
 django==1.8.4
-whitenoise==2.0.2
+whitenoise==2.0.3
 
 # Extensions
 # -------------------------------------
@@ -15,13 +15,13 @@ pytz==2015.4
 django-environ==0.3.0
 django-sites==0.8
 django-secure==1.0.1
-python-dotenv==0.1.2
+python-dotenv==0.1.3
 
 # Models
 # -------------------------------------
 django-model-utils==2.3.1
 django-uuid-upload-path==1.0.0
-django-versatileimagefield==1.0.3
+django-versatileimagefield==1.0.4
 
 # Images
 # -------------------------------------
@@ -38,4 +38,4 @@ django-autoslug==1.8.0
 
 # Django Rest Framework
 # -------------------------------------
-djangorestframework==3.1.3
+djangorestframework==3.2.2

--- a/{{cookiecutter.repo_name}}/requirements/development.txt
+++ b/{{cookiecutter.repo_name}}/requirements/development.txt
@@ -10,7 +10,7 @@ isort==4.0.0
 # -------------------------------------
 django-debug-toolbar==1.3.2
 ipdb==0.8.1
-ipython==3.2.1
+ipython==4.0.0
 
 # Testing and coverage
 # -------------------------------------
@@ -18,7 +18,7 @@ coverage==3.7.1
 factory_boy==2.5.2
 flake8==2.4.1
 git+git://github.com/mverteuil/pytest-ipdb.git
-mock==1.1.2
+mock==1.3.0
 pytest-django==2.8.0
 pytest-pythonpath==0.7
 

--- a/{{cookiecutter.repo_name}}/requirements/production.txt
+++ b/{{cookiecutter.repo_name}}/requirements/production.txt
@@ -5,7 +5,7 @@
 # Static Files and Media Storage
 # -------------------------------------
 boto==2.38.0
-django-storages-redux==1.2.3
+django-storages-redux==1.3
 
 # WSGI HTTP Server
 # -------------------------------------


### PR DESCRIPTION
- python-dotenv
- whitenoise==2.0.3 http://whitenoise.evans.io/en/latest/changelog.html#v2-0-3
- django-versatileimagefield==1.0.4 https://django-versatileimagefield.readthedocs.org/en/latest/#id1
- djangorestframework==3.2.2 http://www.django-rest-framework.org/topics/release-notes/#32x-series
- ipython
- mock==1.3.0 https://github.com/testing-cabal/mock/compare/1.1.2...1.3.0
- django-storages-redux https://github.com/jschneier/django-storages/blob/master/CHANGELOG.rst
