### PR TITLE
fix(fab): use `runserver` instead of 'runserver_plus'

### DIFF
--- a/{{cookiecutter.github_repository}}/fabfile.py
+++ b/{{cookiecutter.github_repository}}/fabfile.py
@@ -89,10 +89,12 @@ def test(options='--pdb --cov'):
 
 
 def serve(host='127.0.0.1:8000'):
-    """Start an enhanced local app server"""
+    """Run local developerment server, making sure that dependencies and
+    database migrations are upto date.
+    """
     install_requirements()
     migrate()
-    manage('runserver_plus %s' % host)
+    manage('runserver %s' % host)
 
 
 def makemigrations(app=''):


### PR DESCRIPTION
> Why was this change necessary?

- It depends on django-extensions and doesn't really solve any problem in a
meaningful ways.
- Most of the developers use runserver and this really avoid any inconsistency
- It's doesn't really well with devcargar (used in auto-reloading)

> How does it address the problem?

Revert back to use `runserver`

> Are there any side effects?

Nope