### PR TITLE
Enable livereload of frontend pages/assets in Development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Removed 'pages' app
 - Project renamed to `django-init`
 
+### Added 
+- Livereload support via devrecargar
+
 ## [1.1.0]
 ### Added
 - Provide a basic override for `admin/base_site.html`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Project template for django based projects, optimized for making REST API with d
 - `travis.yml` for running isolated tests and deployments to dev/qa/prod environment on Heroku from git branches.
 - Custom User app, for easier extensibility.
 - Optional media storage using Amazon S3
+- Livereloading of browser in development via [devrecargar]
 - robots.txt and humans.txt configured
 
 ## Getting Started
@@ -64,3 +65,4 @@ Built with ♥ at [Fueled](http://fueled.com)
 [Procfile]: https://devcenter.heroku.com/articles/procfile
 [django-environ]: https://github.com/joke2k/django-environ
 [Ansible]: http://docs.ansible.com/index.html
+[devrecargar]: https://github.com/scottwoodall/django-devrecargar

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -7,6 +7,10 @@ gunicorn==19.4.5
 mkdocs==0.15.3
 isort==4.2.2
 
+# Livereload
+# -------------------------------------
+devrecargar==0.1.4
+
 # Debugging
 # -------------------------------------
 django-debug-toolbar==1.4

--- a/{{cookiecutter.github_repository}}/settings/development.py
+++ b/{{cookiecutter.github_repository}}/settings/development.py
@@ -7,6 +7,7 @@ Adds sensible defaults for developement of project
 - Enable Django Extensions
 - Enable Django Debug Toolbar
 - Use local caches
+- Enable livereloading
 """
 from __future__ import absolute_import, unicode_literals
 
@@ -47,6 +48,16 @@ CACHES = {
 # django-extensions (http://django-extensions.readthedocs.org/)
 # ------------------------------------------------------------------------------
 INSTALLED_APPS += ('django_extensions', )
+
+# LiveReload Support with devrecargar
+# ------------------------------------------------------------------------------
+# https://github.com/scottwoodall/django-devrecargar
+INSTALLED_APPS += ('devrecargar',)
+
+DEVRECARGAR_PATHS_TO_WATCH = [{
+    'path': str(APPS_DIR),
+    'patterns': ['*.html', '*.js', '*.css', '*.scss'],
+}]
 
 # django-debug-toolbar
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/templates/base.html
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/templates/base.html
@@ -45,6 +45,11 @@
 
       <!-- place project specific Javascript in this file -->
       <script src="{% static 'js/main.js' %}"></script>
+
+      {% if debug %}
+        <!--Livereloading support -->
+        <script>{% include "devrecargar/devrecargar.js" %}</script>
+      {% endif %}
     {% endblock js %}
   </body>
 </html>{% endraw %}

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/urls.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/urls.py
@@ -46,6 +46,9 @@ urlpatterns += [
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG:
+    # Livereloading
+    urlpatterns += [url(r'^devrecargar/', include('devrecargar.urls', namespace='devrecargar'))]
+
     urlpatterns += [
         url(r'^400/$', dj_default_views.bad_request, kwargs={'exception': Exception("Bad Request!")}),
         url(r'^403/$', dj_default_views.permission_denied, kwargs={'exception': Exception("Permission Denied!")}),


### PR DESCRIPTION
> Why was this change necessary?

It makes development with html, js, css, scss way much faster, without the need of any browser plugin. 

> How does it address the problem?

By adding a non-obtrusive, easy to install livereload functionality, all in python. Works great with django-compressor. 

> Are there any side effects?

Probably you would like to remove this if any other liveloading tool is used. e.g. grunt, gulp. 

