### PR TITLE
feat(cookiecutter): make generation of ansible related stuff optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - anisble: Update supervisor init script 
 - travis: Use `pip-accel` on travis along with caching
 - Removed 'pages' app
-- Project renamed to `django-init`
+- Project renamed to `django-init`.
+- Make ansible generation optional.
 
 ### Added 
 - Livereload support via devrecargar

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Project template for django based projects, optimized for making REST API with d
 - Django 1.9.x
 - PostresSQL everywhere(support of postgis is available).
 - [Procfile] for deploying to Heroku.
-- [Ansible] script for quick deployment to Ubuntu based servers.
+- [Ansible] playbook for deployment to Ubuntu 14 LTS. (optional)
 - [12-Factor][12factor] based settings management via [django-environ], reads settings from `.env` if present.
 - Designed to work with Django Rest Framework 3.0+.
 - Uses `django_sites` instead of `django.contrib.sites`
@@ -56,7 +56,7 @@ Refer to [CHANGELOG.md](CHANGELOG.md).
 
 --------
 
-Built with ♥ at [Fueled](http://fueled.com)
+Built with ♥ at [Fueled](https://fueled.com)
 
 [wiki]: https://github.com/Fueled/django-init/wiki
 [mkdocs]: http://www.mkdocs.org/

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,4 +10,5 @@
     , "python3": "n"
     , "newrelic" : "y"
     , "postgis": "n"
+    , "add_ansible": "y"
 }

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -25,7 +25,9 @@ else
     read  yn
 fi
 
-
+if echo "{{ cookiecutter.add_ansible }}" | grep -iq "^n"; then
+    rm -rf provisioner Vagrantfile
+fi
 if echo "$yn" | grep -iq "^y"; then
     echo "==> Checking system dependencies. You may need to enter your sudo password."
 
@@ -47,7 +49,7 @@ if echo "$yn" | grep -iq "^y"; then
     git commit -am "chore(setup): create base django project."
     git tag v{{ cookiecutter.version }}
 
-    echo "==> Setup the project dependencies and database for local development"
+    echo "${green}==> Setup the project dependencies and database for local development${reset}"
     fab init
 
     echo "==> Bumpversion 0.1.0-dev"

--- a/{{cookiecutter.github_repository}}/.travis.yml
+++ b/{{cookiecutter.github_repository}}/.travis.yml
@@ -14,35 +14,28 @@ cache:
 before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 
+install:
+  - pip install pip-accel
+  {%- if cookiecutter.add_ansible.lower() == 'y' %}- pip-accel install ansible{% endif %}
+  - pip-accel install -r requirements/development.txt
+
 before_script:
 - export DATABASE_URL=postgres://postgres@localhost/{{ cookiecutter.main_module }}
 - psql -c "CREATE DATABASE {{ cookiecutter.main_module }};" -U postgres
-{% if cookiecutter.postgis == 'y' -%}
+{%- if cookiecutter.postgis.lower() == 'y' %}
 - psql -c "CREATE EXTENSION postgis;" -U postgres -d {{ cookiecutter.main_module }}
-{% endif %}
-
-cache:
-  directories:
-  - $HOME/.cache/pip
-  - $HOME/.pip-accel
-
-before_cache:
-- rm -f $HOME/.cache/pip/log/debug.log
-
-install:
-  - pip install pip-accel
-  - pip-accel install ansible
-  - pip-accel install -r requirements/development.txt
+{%- endif %}
 
 script:
 - flake8
 - py.test --cov -v --tb=native
-- ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check
+{%- if cookiecutter.add_ansible.lower() == 'y' %}- ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check{% endif %}
 
 notifications:
   email:
     on_success: change  # [always|never|change]
     on_failure: always  # [always|never|change]
+
 deploy:
   provider: heroku
   buildpack: python

--- a/{{cookiecutter.github_repository}}/docs/backend/server_config.md
+++ b/{{cookiecutter.github_repository}}/docs/backend/server_config.md
@@ -85,6 +85,7 @@ DJANGO_AWS_STORAGE_BUCKET_NAME=<YOUR_BUCKET_NAME_HERE>
 - Use `--app=<heroku-app-name>` if you have more than one heroku app configured in current project.
 - Update `travis.yml`, and add the `<heroku-app-name>` to automatically deploy to this configured heroku app.
 
+{%- if cookiecutter.add_ansible.lower() == 'y' %}
 ### AWS/EC2
 
 For deploying on aws you need to configure all the addons provided and use python-dotenv to store and read enironment variables.
@@ -119,3 +120,4 @@ You can also use fab to set environment variables one by one:
 Now that you have `.env` setup, you can deploy your code and start services:
 
     fab prod deploy
+{% endif %}


### PR DESCRIPTION
When it's known for sure that the site won't be deployed to any ubuntu based
machines, having the provisioning script, it's related fab commands and docs
is not very optimal.

If the ansible is required at a later stage then it's needs to be manually. The
user can use the same cookiecutter while saying `add_ansible=y` and then copy
over the required bits.