### PR TITLE
fix(exceptions): fixed django exceptions error handling format.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Make ansible generation optional.
 - Add documentation for Drone.io CI
 - Add Circle CI Support (@jasonrfarkas)
+- Fix `Http404` and `PermissionDenied` error handling format.
 
 ### Added 
 - Livereload support via devrecargar

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/exceptions.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/exceptions.py
@@ -130,11 +130,13 @@ def exception_handler(exc, context=None):
         return Response(detail, status=exc.status_code, headers=headers)
 
     elif isinstance(exc, Http404):
-        return Response({'errors': [{'message': str(exc)}, ]},
+        return Response({'error_type': exc.__class__.__name__,
+                         'errors': [{'message': str(exc)}]},
                         status=status.HTTP_404_NOT_FOUND)
 
     elif isinstance(exc, DjangoPermissionDenied):
-        return Response({'errors': [{'message': str(exc)}, ]},
+        return Response({'error_type': exc.__class__.__name__,
+                         'errors': [{'message': str(exc)}]},
                         status=status.HTTP_403_FORBIDDEN)
 
     # Note: Unhandled exceptions will raise a 500 error.


### PR DESCRIPTION
> Why was this change necessary?

Django 404, ValidationError, PermissionDenied were not following defined error formatting.

> How does it address the problem?

It fixes its formatting to match the existing.

> Are there any side effects?

No

