### PR TITLE
chore(api-settings): remove browsable api from prod environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add documentation for Drone.io CI
 - Add Circle CI Support (@jasonrfarkas)
 - Fix `Http404` and `PermissionDenied` error handling format.
+- Add configurable support for `adding/removing DRF Browsable apis`
 
 ### Added 
 - Livereload support via devrecargar

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -56,11 +56,20 @@ INSTALLED_APPS = (
 AUTH_USER_MODEL = 'users.User'
 AUTHENTICATION_BACKENDS = ("django.contrib.auth.backends.ModelBackend",)
 
+# For Exposing browsable api urls. By default urls won't be exposed.
+API_DEBUG = env.bool('API_DEBUG', default=False)
+
 # rest_framework
 # ------------------------------------------------------------------------------
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': '{{ cookiecutter.main_module }}.base.api.pagination.PageNumberPagination',
     'PAGE_SIZE': 30,
+
+    # Default renderer classes for Rest framework
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
+    ],
 
     # 'Accept' header based versioning
     # http://www.django-rest-framework.org/api-guide/versioning/
@@ -68,10 +77,6 @@ REST_FRAMEWORK = {
     'DEFAULT_VERSION': '1.0',
     'ALLOWED_VERSIONS': ['1.0', ],
     'VERSION_PARAMETER': 'version',
-
-    # Use hyperlinked styles by default.
-    # Only used if the `serializer_class` attribute is not set on a view.
-    'DEFAULT_MODEL_SERIALIZER_CLASS': 'rest_framework.serializers.HyperlinkedModelSerializer',
 
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.

--- a/{{cookiecutter.github_repository}}/settings/development.py
+++ b/{{cookiecutter.github_repository}}/settings/development.py
@@ -74,3 +74,6 @@ DEBUG_TOOLBAR_CONFIG = {
     'DISABLE_PANELS': ['debug_toolbar.panels.redirects.RedirectsPanel', ],
     'SHOW_TEMPLATE_CONTEXT': True,
 }
+
+# This will expose all browsable api urls. For dev the default value is true
+API_DEBUG = env.bool('API_DEBUG', default=True)

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -140,3 +140,8 @@ TEMPLATES[0]['OPTIONS']['loaders'] = [
 ]
 
 # Your production stuff: Below this line define 3rd party libary settings
+
+if not API_DEBUG:
+    # blocking browsable api for rest framework and allowing just json renderer
+    if 'rest_framework.renderers.BrowsableAPIRenderer' in REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES']:
+        REST_FRAMEWORK['DEFAULT_RENDERER_CLASSES'].remove('rest_framework.renderers.BrowsableAPIRenderer')

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/urls.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/urls.py
@@ -45,6 +45,12 @@ urlpatterns += [
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+if settings.API_DEBUG:
+    urlpatterns += [
+        # Browsable API
+        url(r'^api/auth-n/', include('rest_framework.urls', namespace='rest_framework')),
+    ]
+
 if settings.DEBUG:
     # Livereloading
     urlpatterns += [url(r'^devrecargar/', include('devrecargar.urls', namespace='devrecargar'))]


### PR DESCRIPTION
> Why was this change necessary?

We may not want to give browsable api interface on staging or prod environments.

> How does it address the problem?

We now have a setting variable that allows us to enable the browsable api on any of the environment. By default the browsable api would be turned off for all the environment except local development environment.

> Are there any side effects?

No
