### PR TITLE
feat(provisioner/letsencrypt): add letsencrypt ansible configuration

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/letsencrypt/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/letsencrypt/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+  letsencrypt_src_directory: /usr/local/share/letsencrypt
+  letsencrypt_venv: "{{ letsencrypt_src_directory }}/env"
+  letsencrypt_cert_domains:
+    - "{{ ansible_fqdn }}"
+  letsencrypt_webroot_path: /var/www
+  letsencrypt_authenticator: webroot
+  letsencrypt_email: "webmaster@{{ ansible_domain }}"
+  letsencrypt_command: "{{ letsencrypt_venv }}/bin/letsencrypt --agree-tos  {% if letsencrypt_rsa_key_size is defined %}--rsa-key-size {{ letsencrypt_rsa_key_size }}{% endif %} --text {% for domain in letsencrypt_cert_domains %}-d {{ domain }} {% endfor %}--email {{ letsencrypt_email }} {% if letsencrypt_server is defined %}--server {{ letsencrypt_server }}{% endif %} --expand"
+  letsencrypt_renewal_frequency:
+    day: "*"
+    hour: 0
+    minute: 0
+  letsencrypt_renewal_command_args: ''

--- a/{{cookiecutter.github_repository}}/provisioner/roles/letsencrypt/meta/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/letsencrypt/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/{{cookiecutter.github_repository}}/provisioner/roles/letsencrypt/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/letsencrypt/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+  - apt: update_cache=yes cache_valid_time=3600
+    become: yes
+
+  - name: Install depends
+    apt: name={{ item }} state=present
+    become: yes
+    with_items:
+      - python
+      - python-dev
+      - python-virtualenv
+      - gcc
+      - dialog
+      - libaugeas0
+      - libssl-dev
+      - libffi-dev
+      - ca-certificates
+      - python-pip
+      - git
+
+  - name: Install virtualenv (Debian)
+    apt: name={{ item }} state=present
+    become: yes
+    with_items:
+      - virtualenv
+    when: ansible_distribution == 'Debian' and ansible_lsb.codename !=  "wheezy"
+
+  - name: Install virtualenv (Debian Wheezy)
+    apt: name={{ item }} state=present
+    become: yes
+    with_items:
+      - python-virtualenv
+    when: ansible_distribution == 'Debian' and ansible_lsb.codename ==  "wheezy"
+
+  - name: Install python depends
+    pip: virtualenv="{{ letsencrypt_venv }}" virtualenv_site_packages=no name={{ item }} state=latest
+    become: yes
+    with_items:
+      - setuptools
+      - pip
+
+  - name: More python depends
+    pip: virtualenv="{{ letsencrypt_venv }}" virtualenv_site_packages=no name=letsencrypt state=latest
+    become: yes
+
+  - name: Ensure webroot exists
+    file: path="{{ letsencrypt_webroot_path }}" state=directory
+    become: yes
+
+  - name: Attempt to get the certificate using the webroot authenticator
+    command: "{{ letsencrypt_command }} -a webroot --webroot-path {{ letsencrypt_webroot_path }} certonly"
+    become: yes
+    args:
+      creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
+    when: letsencrypt_authenticator == "webroot"
+    ignore_errors: True
+
+  - name: Attempt to get the certificate using the standalone authenticator (in case eg the webserver isn't running yet)
+    command: "{{ letsencrypt_command }} -a standalone auth"
+    become: yes
+    args:
+      creates: "/etc/letsencrypt/live/{{ letsencrypt_cert_domains[0] }}"
+
+  - name: Fix the renewal file
+    ini_file: section=renewalparams option={{ item.key }} value={{ item.value }} dest="/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
+    become: yes
+    with_dict:
+      os_packages_only: False
+      verb: certonly
+      noninteractive_mode: False
+      uir: False
+      hsts: False
+      authenticator: '{{ letsencrypt_authenticator }}'
+
+  - name: Fix the webroot map in the renewal file
+    ini_file: section="[webroot_map]" option={{ item }} value={{ letsencrypt_webroot_path }} dest="/etc/letsencrypt/renewal/{{ letsencrypt_cert_domains[0] }}.conf"
+    become: yes
+    with_items: "{{ letsencrypt_cert_domains }}"
+
+  - name: Install renewal cron
+    become: yes
+    cron: name="Let's Encrypt Renewal" day="{{ letsencrypt_renewal_frequency.day }}" hour="{{ letsencrypt_renewal_frequency.hour }}" minute="{{ letsencrypt_renewal_frequency.minute }}" job="{{ letsencrypt_venv }}/bin/letsencrypt renew {{ letsencrypt_renewal_command_args }} > /dev/null"

--- a/{{cookiecutter.github_repository}}/provisioner/site.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/site.yml
@@ -12,6 +12,7 @@
     - supervisor
     - postgresql
     - project_data
+    - letsencrypt
     # - redis
     # - celery
 
@@ -28,5 +29,6 @@
     - nginx
     - supervisor
     - project_data
+    - letsencrypt
     # - redis
     # - celery


### PR DESCRIPTION
> Why was this change necessary?
- The encryption within HTTPS is intended to provide benefits like confidentiality, integrity and identity. Your information remains confidential from prying eyes because only your browser and the server can decrypt the traffic. Integrity protects the data from being modified without your knowledge.

> How does it address the problem?

- Supports `letsencrypt` hence giving developer flexibility to add `https` in production. 

> Are there any side effects?

Not that I encounter. 
