### PR TITLE
feat(django/admin): Allow customizing admin url path via environ

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -177,6 +177,10 @@ WSGI_APPLICATION = 'wsgi.application'
 # ------------------------------------------------------------------------------
 ROOT_URLCONF = '{{ cookiecutter.main_module }}.urls'
 
+
+# Use this to change base url path django admin
+DJANGO_ADMIN_URL = env.str('DJANGO_ADMIN_URL', default='admin')
+
 # EMAIL CONFIGURATION
 # ------------------------------------------------------------------------------
 EMAIL_BACKEND = env('DJANGO_EMAIL_BACKEND',

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/urls.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/urls.py
@@ -41,7 +41,7 @@ urlpatterns += [
     url(r'^api/auth-n/', include('rest_framework.urls', namespace='rest_framework')),
 
     # Django Admin
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^{}/'.format(settings.DJANGO_ADMIN_URL), include(admin.site.urls)),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 


### PR DESCRIPTION
> Why was this change necessary?

Customizing admin url between different environment is not possible with current hardcoded path.

> How does it address the problem?

Allow customizing admin url path via environment variable.

> Are there any side effects?

No. The default is the same.

