### PR TITLE
refractor(tests): use django-dynamic-fixtures instead of factory-boy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.2.0-dev]
 ### Changed
+- Remove factoryboy, use [django-dynamic-fixtures] for factories.
 - Update SERVER_EMAIL settings to default to DEFAULT_FROM_EMAIL
 - Use `setup.cfg` instead of `.bumpversion`
 - Use `setup.cfg` instead of `.coveragerc`
@@ -17,6 +18,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add Circle CI Support (@jasonrfarkas)
 - Fix `Http404` and `PermissionDenied` error handling format.
 - Add configurable support for `adding/removing DRF Browsable apis`
+
+[django-dynamic-fixtures]: https://github.com/paulocheque/django-dynamic-fixture
 
 ### Added 
 - Livereload support via devrecargar

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -21,7 +21,7 @@ django-extensions==1.6.7  # for shell_plus and other utils
 pytest-django==2.9.1
 pytest-pythonpath==0.7
 pytest-cov==2.2.1
-factory_boy==2.7.0
+django-dynamic-fixture==1.9.0
 mock==2.0.0
 flake8==2.5.4
 

--- a/{{cookiecutter.github_repository}}/tests/factories.py
+++ b/{{cookiecutter.github_repository}}/tests/factories.py
@@ -1,25 +1,26 @@
 # -*- coding: utf-8 -*-
+"""
+Helpers to create dynamic model instances for testing purposes.
+
+Usages:
+>>> from tests import factories as f
+>>>
+>>> user = f.create_user(first_name="Robert", last_name="Downey")  # creates single instance of user
+>>> users = f.create_user(n=5, is_active=False)  # creates 5 instances of user
+
+There is a bit of magic going on behind the scenes with `G` method from https://django-dynamic-fixture.readthedocs.io/
+"""
 
 # Third Party Stuff
-import factory
+from django.apps import apps
 from django.conf import settings
-
-
-class Factory(factory.DjangoModelFactory):
-    class Meta:
-        strategy = factory.CREATE_STRATEGY
-        model = None
-        abstract = True
-
-
-class UserFactory(Factory):
-    class Meta:
-        model = settings.AUTH_USER_MODEL
-
-    email = factory.Sequence(lambda n: 'user%04d@email.com' % n)
-    password = factory.PostGeneration(lambda obj, *args, **kwargs: obj.set_password('123123'))
+from django_dynamic_fixture import G
 
 
 def create_user(**kwargs):
     """Create an user along with their dependencies."""
-    return UserFactory.create(**kwargs)
+    User = apps.get_model(settings.AUTH_USER_MODEL)
+    user = G(User, **kwargs)
+    user.set_password(kwargs.get('password', 'test'))
+    user.save()
+    return user


### PR DESCRIPTION
* Why was this change necessary?

Simplifies writing factories and prevents duplication of model defination.

* How does it address the problem?

django-dynamic-fixtures provies two methods `G/get` and `N/new` that provides defaults
for almost all the model field types and default rules for custom field types can
be easily setup.

* Are there any side effects?

Not for any new projects, just that devs need to be familiar with DDF to be utilize
it at best! ;)