### PR TITLE
Add support for `Logging` (#169)

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -37,3 +37,7 @@ django-compressor==2.0
 django-libsass==0.7
 django-compressor-autoprefixer==0.1.0
 {%- endif %}
+
+# LOGGING
+# -------------------------------------
+django-log-request-id==1.1.0


### PR DESCRIPTION
> Why was this change necessary?

Currently there is no way we can log the things and check if somethings goes wrong on the servers

> How does it address the problem?

This pull request adds the logging support for django, All the logs are send to the standard output. Also this pull request add support for request ids. Unique Request ids are generated for each and every request, which makes debugging in production easier.

> Are there any side effects?

Nothing as of now.   
