### PR TITLE
Update requirements to latest.

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -1,34 +1,34 @@
 # Core Stuff
 # -------------------------------------
-Django==1.9.6
+Django==1.9.8
 gunicorn==19.6.0
 
 # Configuration
 # -------------------------------------
 django-environ==0.4.0
 django-sites==0.9
-python-dotenv==0.5.0
+python-dotenv==0.5.1
 
 # Staticfiles
 # -------------------------------------
-whitenoise==3.1
+whitenoise==3.2
 
 # Extensions
 # -------------------------------------
-pytz==2016.4
+pytz==2016.6.1
 
 # Models
 # -------------------------------------
-psycopg2==2.6.1
+psycopg2==2.6.2
 django-model-utils==2.5
 
-Pillow==3.2.0
-django-versatileimagefield==1.4
+Pillow==3.3.0
+django-versatileimagefield==1.5
 django-uuid-upload-path==1.0.0
 
 # REST APIs
 # -------------------------------------
-djangorestframework==3.3.3
+djangorestframework==3.4.0
 {%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' %}
 
 # Static files

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -12,15 +12,14 @@ devrecargar==0.1.4
 # Debugging
 # -------------------------------------
 django-debug-toolbar==1.4
-ipdb==0.10.0
-ipython==4.2.0
+ipdb==0.10.1
 django-extensions==1.6.7  # for shell_plus and other utils
 
 # Testing and coverage
 # -------------------------------------
 pytest-django==2.9.1
 pytest-pythonpath==0.7
-pytest-cov==2.2.1
+pytest-cov==2.3.0
 django-dynamic-fixture==1.9.0
 mock==2.0.0
 flake8==2.5.4

--- a/{{cookiecutter.github_repository}}/requirements/production.txt
+++ b/{{cookiecutter.github_repository}}/requirements/production.txt
@@ -4,7 +4,7 @@
 
 # Static Files and Media Storage
 # -------------------------------------
-boto==2.40.0
+boto==2.42.0
 django-storages-redux==1.3.2
 
 # Caching


### PR DESCRIPTION
*Major changes*
Django==1.9.8
djangorestframework==3.4.0
whitenoise==3.2
Pillow==3.3.0
boto==2.42.0

Not upgrading flake8 to 2.6 as it has some breaking changes