### PR TITLE
chore(pytest-warning): removed WC1 pytest warning in CI

### DIFF
--- a/{{cookiecutter.github_repository}}/setup.cfg
+++ b/{{cookiecutter.github_repository}}/setup.cfg
@@ -25,7 +25,7 @@ values =
 max-line-length = 120
 exclude = .tox,.git,*/migrations/*,*/static/*,docs,venv
 
-[pytest]
+[tool:pytest]
 DJANGO_SETTINGS_MODULE = settings.testing
 norecursedirs = .tox .git */migrations/* */static/* docs venv
 


### PR DESCRIPTION
> Why was this change necessary?

removed warning in CI environment. 
> How does it address the problem?

Changing [pytest] to [tools:pytest] removed this warning. Also in Pytest 4.0 we need to have setup.cfg as per this format as the current format will be deprecated. 
> Are there any side effects?

No. The sample project tests passed successfully on my CI. 

- changed [pytest] to [tool:pytest] in setup.cfg to ignore `WC1 None` warning