### PR TITLE
Update Node Dependency

### DIFF
--- a/{{cookiecutter.github_repository}}/package.json
+++ b/{{cookiecutter.github_repository}}/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Installs commandline tools needed by django-compressor for post-processing of css/js.",
   "engines": {
-    "node": "5.11.0"
+    "node": "6.4.0"
   },
   "dependencies": {
     "autoprefixer": "^6.1.1",


### PR DESCRIPTION
#> Why was this change necessary?

postcss-cli required latest version of node.

> How does it address the problem?

Resolves the issue.

- Upgrade to node version to 6.4.0 from 5.11.0

postcss-cli required the latest version of node.