### PR TITLE
Update requirements to latest stable.

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -8,11 +8,11 @@ gunicorn==19.6.0
 argon2-cffi==16.1.0
 django-environ==0.4.0
 django-sites==0.9
-python-dotenv==0.5.1
+python-dotenv==0.6.0
 
 # Staticfiles
 # -------------------------------------
-whitenoise==3.2
+whitenoise==3.2.1
 
 # Extensions
 # -------------------------------------
@@ -22,13 +22,13 @@ pytz==2016.6.1
 # -------------------------------------
 psycopg2==2.6.2
 
-Pillow==3.3.0
+Pillow==3.3.1
 django-versatileimagefield==1.6
 django-uuid-upload-path==1.0.0
 
 # REST APIs
 # -------------------------------------
-djangorestframework==3.4.3
+djangorestframework==3.4.6
 {%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' %}
 
 # Static files
@@ -40,4 +40,4 @@ django-compressor-autoprefixer==0.1.0
 
 # LOGGING
 # -------------------------------------
-django-log-request-id==1.1.0
+django-log-request-id==1.3.1

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -13,12 +13,12 @@ devrecargar==0.1.4
 # -------------------------------------
 django-debug-toolbar==1.5
 ipdb==0.10.1
-django-extensions==1.7.1  # for shell_plus and other utils
+django-extensions==1.7.4  # for shell_plus and other utils
 
 # Testing and coverage
 # -------------------------------------
-pytest-django==2.9.1
-pytest-pythonpath==0.7
+pytest-django==3.0.0 # Updated from 2.9.1
+pytest-pythonpath==0.7.1
 pytest-cov==2.3.1
 django-dynamic-fixture==1.9.0
 mock==2.0.0

--- a/{{cookiecutter.github_repository}}/requirements/production.txt
+++ b/{{cookiecutter.github_repository}}/requirements/production.txt
@@ -15,5 +15,5 @@ hiredis==0.2.0
 {% if cookiecutter.newrelic == 'y' %}
 # Logging
 # -------------------------------------
-newrelic==2.68.0.50
+newrelic==2.70.0.51
 {% endif %}


### PR DESCRIPTION
Major releases:

pytest-django==3.0.0 (http://docs.pytest.org/en/latest/changelog.html)
python-dotenv==0.6.0 (https://pypi.python.org/pypi/python-dotenv/0.6.0#changelog)
django-log-request-id==1.3.1 (https://github.com/dabapps/django-log-request-id/commits/master)

Minor release:

django-extensions==1.7.4
djangorestframework==3.4.6
whitenoise==3.2.1
Pillow==3.3.1
pytest-pythonpath==0.7.1