### PR TITLE
Add support for gitlab-ci.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Project template for django based projects, optimized for making REST API with d
 - Use [mkdocs] for project documentation.
 - Uses [py.test] as test runner.
 - `travis.yml` for running isolated tests and deployments to dev/qa/prod environment on Heroku from git branches.
+- `gitlab-ci.yml` for running isolated tests.
 - Custom `User` app, for easier extensibility.
 - Media storage using Amazon S3 (optional)
 - [Letsencrypt](https://letsencrypt.org/) Support via [certbot](https://certbot.eff.org)

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,7 @@
     , "newrelic" : "y"
     , "postgis": "n"
     , "add_ansible": "y"
+    , "add_gitlab_ci":  "y"
     , "letsencrypt": "y"
     , "letsencrypt_email": "backend+{{ cookiecutter.main_module|replace('_', '-') }}@fueled.com"
     , "add_sass_with_django_compressor": "y"

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -29,6 +29,10 @@ if echo "{{ cookiecutter.add_ansible }}" | grep -iq "^n"; then
     rm -rf provisioner Vagrantfile
 fi
 
+if echo "{{ cookiecutter.add_gitlab_ci}}" | grep -iq "^n"; then
+    rm -rf .gitlab-ci.yaml
+fi
+
 if echo "{{ cookiecutter.add_sass_with_django_compressor }}" | grep -iq "^n"; then
     rm -rf package.json
 else

--- a/{{cookiecutter.github_repository}}/.gitlab-ci.yml
+++ b/{{cookiecutter.github_repository}}/.gitlab-ci.yml
@@ -8,11 +8,6 @@ variables:
     POSTGRES_USER: postgres
     POSTGRES_PASSWORD: postgres
 
-before_script:
-    - apt-get update -qy
-    - apt-get install -y python3-dev libpq-dev
-    - export DATABASE_URL=postgres://postgres:postgres@postgres/{{ cookiecutter.main_module }}
-
 lint:
     script:
         - pip install flake8==2.5.4
@@ -20,6 +15,9 @@ lint:
 
 django_app:
     script:
+        - apt-get update -qy
+        - apt-get install -y python3-dev libpq-dev
+        - export DATABASE_URL=postgres://postgres:postgres@postgres/{{ cookiecutter.main_module }}
         - pip install -r requirements/development.txt
         - py.test --cov -v --tb=native
 
@@ -28,6 +26,4 @@ ansible:
     script:
         - pip install ansible
         - ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check
-    only:
-        - master
 {% endif %}

--- a/{{cookiecutter.github_repository}}/.gitlab-ci.yml
+++ b/{{cookiecutter.github_repository}}/.gitlab-ci.yml
@@ -28,4 +28,6 @@ ansible:
     script:
         - pip install ansible
         - ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check
+    only:
+        - master
 {% endif %}

--- a/{{cookiecutter.github_repository}}/.gitlab-ci.yml
+++ b/{{cookiecutter.github_repository}}/.gitlab-ci.yml
@@ -1,0 +1,27 @@
+services:
+    - postgres
+
+variables:
+    # Configure postgres service
+    POSTGRES_DB: {{ cookiecutter.main_module }}
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: mypassword
+
+before_script:
+    - apt-get update -qy
+    - apt-get upgrade -qy
+    - apt-get install -y python-dev python-pip libpq-dev
+    - export DATABASE_URL=postgres://postgres@localhost/{{ cookiecutter.main_module }}
+
+lint:
+    script:
+        - pip install flake8==2.5.4
+        - flake8 .
+
+django_app:
+    script:
+        - pip install pip-accel
+        - pip-accel install ansible
+        - pip-accel install -r requirements/development.txt
+        - py.test --cov -v --tb=native
+        {% if cookiecutter.add_ansible.lower() == 'y' %}- ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check{% endif %}

--- a/{{cookiecutter.github_repository}}/.gitlab-ci.yml
+++ b/{{cookiecutter.github_repository}}/.gitlab-ci.yml
@@ -1,17 +1,17 @@
+image: python:3.5.2
 services:
-    - postgres
+    - postgres:9.4
 
 variables:
     # Configure postgres service
     POSTGRES_DB: {{ cookiecutter.main_module }}
     POSTGRES_USER: postgres
-    POSTGRES_PASSWORD: mypassword
+    POSTGRES_PASSWORD: postgres
 
 before_script:
     - apt-get update -qy
-    - apt-get upgrade -qy
-    - apt-get install -y python-dev python-pip libpq-dev
-    - export DATABASE_URL=postgres://postgres@localhost/{{ cookiecutter.main_module }}
+    - apt-get install -y python3-dev libpq-dev
+    - export DATABASE_URL=postgres://postgres:postgres@postgres/{{ cookiecutter.main_module }}
 
 lint:
     script:
@@ -20,8 +20,12 @@ lint:
 
 django_app:
     script:
-        - pip install pip-accel
-        - pip-accel install ansible
-        - pip-accel install -r requirements/development.txt
+        - pip install -r requirements/development.txt
         - py.test --cov -v --tb=native
-        {% if cookiecutter.add_ansible.lower() == 'y' %}- ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check{% endif %}
+
+{% if cookiecutter.add_ansible.lower() == 'y' %}
+ansible:
+    script:
+        - pip install ansible
+        - ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check
+{% endif %}

--- a/{{cookiecutter.github_repository}}/tests/integration/test_site_pages.py
+++ b/{{cookiecutter.github_repository}}/tests/integration/test_site_pages.py
@@ -2,6 +2,9 @@
 
 # Third Party Stuff
 from django.core.urlresolvers import reverse
+import pytest
+
+pytestmark = pytest.mark.django_db
 
 
 def test_root_txt_files(client):

--- a/{{cookiecutter.github_repository}}/tests/integration/test_site_pages.py
+++ b/{{cookiecutter.github_repository}}/tests/integration/test_site_pages.py
@@ -2,9 +2,6 @@
 
 # Third Party Stuff
 from django.core.urlresolvers import reverse
-import pytest
-
-pytestmark = pytest.mark.django_db
 
 
 def test_root_txt_files(client):


### PR DESCRIPTION
> Why was this change necessary?
- GItlab offers free unlimited private repositories.
- With every merge request, it triggers a CI pipeline.
- Adding support for gitlab-ci will enable users to use the CI feature of gitlab

> How does it address the problem?
- It adds the support to use gitlab-ci

> Are there any side effects?

No
