### PR TITLE
fix(debug-toolbar): As per django-debug-toolbar 1.6 we need to manual…

### DIFF
--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/urls.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/urls.py
@@ -53,6 +53,12 @@ if settings.DEBUG:
     from django.views import defaults as dj_default_views
     from django.urls import get_callable
 
+    # debug toolbar
+    import debug_toolbar
+    urlpatterns += [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ]
+
     # Livereloading
     urlpatterns += [url(r'^devrecargar/', include('devrecargar.urls', namespace='devrecargar'))]
 


### PR DESCRIPTION
> Why was this change necessary?

With update of django debug toolbar 1.6 this is the required change. else it breaks the development environment.

> Are there any side effects?
Nothing as of now. 