### PR TITLE
Fix letsencrtypt, make certbot-auto run in non-interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add django_auth_wall to protect staging environments (@theskumar)
 - Replace gunicorn with uwsgi as wsgi handler (@vikalpj)
 
+### Fixes
+- Fix letsencrtypt, make certbot-auto run in non-interactive mode.
+
 ## [1.9.0]
 
 ### Added

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
@@ -19,7 +19,7 @@
 
 # running cron job each monday
 - name: add letsencrypt renew cron
-  cron: name="Renew all certificates" minute="0" hour="2" weekday="1" job="PATH=$PATH:/usr/local/bin && certbot-auto renew --non-interactive --webroot -w {{ letsencrypt_challange_root }}  >> /var/log/certbot.log"
+  cron: name="Renew all certificates" minute="0" hour="2" weekday="1" job="PATH=$PATH:/usr/local/bin && certbot-auto renew --non-interactive --webroot -w {{ letsencrypt_challange_root }}  >> /var/log/certbot.log && service nginx reload"
   when: vm == 0 and use_letsencrypt
 
 - name: check ssl/nginx.crt exists

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
@@ -19,7 +19,7 @@
 
 # running cron job each monday
 - name: add letsencrypt renew cron
-  cron: name="Renew all certificates" minute="0" hour="2" weekday="1" job="PATH=$PATH:/usr/local/bin && certbot-auto renew --webroot -w {{ letsencrypt_challange_root }}  >> /var/log/certbot.log"
+  cron: name="Renew all certificates" minute="0" hour="2" weekday="1" job="PATH=$PATH:/usr/local/bin && certbot-auto renew --non-interactive --webroot -w {{ letsencrypt_challange_root }}  >> /var/log/certbot.log"
   when: vm == 0 and use_letsencrypt
 
 - name: check ssl/nginx.crt exists


### PR DESCRIPTION
Current version of certbot-auto was doesn't work in non-interactive mode if the
flag is not provided. This commit fixes it.