### PR TITLE
fix(django_compressor): Fix issues with nodejs setup django compressor

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/meta/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - { role: nodejs, when: sass_with_django_compressor }


### PR DESCRIPTION
> Why was this change necessary?

Was a missout when switching to ubuntu 16.

> How does it address the problem?

Added the missing file that setups nodejs

> Are there any side effects?

nope 
