### PR TITLE
fix(ansible/postgresql): add hstore to default template in postgresql

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/tasks/main.yml
@@ -19,6 +19,11 @@
     state: installed
   when: pg_gis
 
+- name: add hstore to default template
+  become_user: postgres
+  shell: psql -d template1 -c "CREATE EXTENSION IF NOT EXISTS hstore;"
+  when: pg_hstore
+
 - name: setup database
   become_user: postgres
   postgresql_db:
@@ -28,11 +33,6 @@
     lc_ctype: 'en_US.UTF-8'
     template: 'template0'
     state: present
-
-- name: add hstore
-  become_user: postgres
-  shell: psql {{ pg_db }} -c "CREATE EXTENSION IF NOT EXISTS hstore;"
-  when: pg_hstore
 
 - name: add postgis
   become_user: postgres

--- a/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/tasks/main.yml
@@ -31,7 +31,7 @@
     encoding: 'UTF-8'
     lc_collate: 'en_US.UTF-8'
     lc_ctype: 'en_US.UTF-8'
-    template: 'template0'
+    template: 'template1'
     state: present
 
 - name: add postgis


### PR DESCRIPTION
> Why was this change necessary?

If we create another db on server or run tests on the server, they will fail because of not having hstore extension.

> How does it address the problem?

After setting up, it will add hstore extension to default template which will add this extension to all databases on creation.

> Are there any side effects?

No
