### PR TITLE
Load .env for running Py.test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixes
 - Fix letsencrtypt, make certbot-auto run in non-interactive mode.
+- Fix `py.test` to load values from .env
 
 ## [1.9.0]
 

--- a/{{cookiecutter.github_repository}}/settings/testing.py
+++ b/{{cookiecutter.github_repository}}/settings/testing.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
 from .development import *  # noqa F405
 
 MEDIA_ROOT = "/tmp"

--- a/{{cookiecutter.github_repository}}/settings/testing.py
+++ b/{{cookiecutter.github_repository}}/settings/testing.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-
+# Do this here, so that .env get loaded while running `py.test` from shell
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
+
 from .development import *  # noqa F405
 
 MEDIA_ROOT = "/tmp"

--- a/{{cookiecutter.github_repository}}/settings/testing.py
+++ b/{{cookiecutter.github_repository}}/settings/testing.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 # Do this here, so that .env get loaded while running `py.test` from shell
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())


### PR DESCRIPTION
> Why was this change necessary?

Previously its not loading `.env` file for `py.test` run

> How does it address the problem?

It'll load in `settings/testing`  using `python-dotenv`

> Are there any side effects?
No.
