### PR TITLE
enable support for newer aws regions

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/production.txt
+++ b/{{cookiecutter.github_repository}}/requirements/production.txt
@@ -4,8 +4,8 @@
 
 # Static Files and Media Storage
 # -------------------------------------
-boto==2.45.0
-django-storages-redux==1.3.2
+django-storages==1.5.2
+boto3==1.4.4
 
 # Caching
 # -------------------------------------

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -87,12 +87,15 @@ if ENABLE_MEDIA_UPLOAD_TO_S3:
     # ------------------------
     # See: http://django-storages.readthedocs.org/en/latest/index.html
     INSTALLED_APPS += ('storages',)
-    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'
+    DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
 
     AWS_ACCESS_KEY_ID = env('DJANGO_AWS_ACCESS_KEY_ID')
     AWS_SECRET_ACCESS_KEY = env('DJANGO_AWS_SECRET_ACCESS_KEY')
     AWS_STORAGE_BUCKET_NAME = env('DJANGO_AWS_STORAGE_BUCKET_NAME')
     AWS_QUERYSTRING_AUTH = False
+    AWS_S3_HOST = env('DJANGO_AWS_S3_HOST')
+    AWS_S3_REGION_NAME = env('DJANGO_AWS_S3_REGION_NAME')
+    AWS_S3_SIGNATURE_VERSION = env('DJANGO_AWS_S3_SIGNATURE_VERSION')
 
     # AWS cache settings, don't change unless you know what you're doing.
     AWS_EXPIRY = 60 * 60 * 24 * 7  # 1 week


### PR DESCRIPTION
In order to setup s3 in mumbai region aka ap-south-1 as the static / media backend
the project would have to use `storages.backends.s3boto3.S3Boto3Storage`, which in
turn would need boto3 instead of boto and the newest version of django-storages.

django-storages-redux has not been updated since Jan 2016 and has been releasing on
pypi as django-storages since Feb 2016 when it became the official successor of the
repository it was a fork of[1].

[1] https://github.com/jschneier/django-storages#history
[2] https://github.com/jschneier/django-storages/issues/28#issuecomment-265876674

> Why was this change necessary?

Trouble uploading to s3 in mumbai region

> How does it address the problem?

adds required environment variables and upgrades boto3 and django-storages to their latest versions.

> Are there any side effects?

Not in my knowledge.
