### PR TITLE
fix(provisioner/project): Give uwsgi group the ownership of project dir

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
@@ -1,4 +1,8 @@
 {% raw %}---
+- name: make sure project directory is owned by uwsgi group
+  file: path={{ project_path }} state=directory owner={{user}} group={{uwsgi_group}} recurse=yes
+  tags: ['configure']
+
 - name: get the latest code
   git: repo={{ project_repo_url }} dest={{ project_path }} version={{ repo_version }} accept_hostkey=true
   become: false


### PR DESCRIPTION
fixes #215

> Why was this change necessary?

Project dir is owned by completely different user and uwsgi process is run by other. So if we are using local media files upload, it create problems

> How does it address the problem?

We are giving uwsgi user group, `www-data` ownership of project dir

> Are there any side effects?

No
