### PR TITLE
Fix: use default username, password for postgresql.

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/defaults/main.yml
@@ -2,5 +2,5 @@
 pg_hstore: False
 pg_gis: False
 pg_db: '{% raw %}{{ project_name }}-{{ environment }}{% endraw %}'
-pg_user: dev
-pg_password: password
+pg_user: '{% raw %}{{ pg_user }}{% endraw %}'
+pg_password: '{% raw %}{{ pg_password }}{% endraw %}'


### PR DESCRIPTION
Signed-off-by: Abhishek Kumar Singh <abhishek4bhopati@gmail.com>

> Why was this change necessary?

To run django's migrate command in vagrant box.

> How does it address the problem?

It'll use default vagrant user to connect to database by populating same value to .env file

> Are there any side effects?

No
