### PR TITLE
Added `ALLOWED HOSTS` and updated `INTERNAL_IPS` list for vagrant run.

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/development.py
+++ b/{{cookiecutter.github_repository}}/settings/development.py
@@ -18,7 +18,9 @@ from .common import INSTALLED_APPS, env
 DEBUG = env.bool('DJANGO_DEBUG', default=True)
 TEMPLATES[0]['OPTIONS']['debug'] = DEBUG  # noqa: F405
 
-INTERNAL_IPS = ('127.0.0.1', )
+INTERNAL_IPS = ('127.0.0.1', '192.168.33.12', )
+
+ALLOWED_HOSTS = ["*"]
 
 # Staticfiles
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Abhishek Kumar Singh <abhishek4bhopati@gmail.com>

> Why was this change necessary?

It'll allow any host to access server running under vagrant box.

> How does it address the problem?

Adding `ALLOWED_HOSTS` to `*`

> Are there any side effects?

No
