### PR TITLE
chore(ansible/nginx): Check nginx config before reload/restart

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/handlers/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/handlers/main.yml
@@ -1,6 +1,26 @@
 ---
 - name: restart nginx
-  service: name=nginx state=restarted
+  debug: msg="checking config first"
+  changed_when: True
+  notify:
+    - check nginx configuration
+    - restart nginx - after config check
 
 - name: reload nginx
+  debug: msg="checking config first"
+  changed_when: True
+  notify:
+    - check nginx configuration
+    - reload nginx - after config check
+
+- name: check nginx configuration
+  command: "nginx -t"
+  register: result
+  changed_when: "result.rc != 0"
+  check_mode: no
+
+- name: restart nginx - after config check
+  service: name=nginx state=restarted
+
+- name: reload nginx - after config check
   service: name=nginx state=reloaded

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
@@ -39,29 +39,29 @@
 
 - name: copy base nginx configuration.
   template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf
-  notify: restart nginx
+  notify: reload nginx
 
 - name: delete default vhost.
   action: file path=/etc/nginx/sites-enabled/default state=absent
-  notify: restart nginx
+  notify: reload nginx
 
 - name: copy site host port 80 configuration.
   template: src=site.80.conf.j2 dest=/etc/nginx/sites-available/{{ nginx_conf_file_name }}.80.conf
-  notify: restart nginx
+  notify: reload nginx
 
 - name: copy site host port 443 configuration.
   template: src=site.443.conf.j2 dest=/etc/nginx/sites-available/{{ nginx_conf_file_name }}.443.conf
   when: nginx_cert.stat.exists == true and nginx_key.stat.exists == true
-  notify: restart nginx
+  notify: reload nginx
 
 - name: put host port 80 configuration in sites-enabled
   file: src=/etc/nginx/sites-available/{{ nginx_conf_file_name }}.80.conf dest=/etc/nginx/sites-enabled/{{ nginx_conf_file_name }}.80 state=link
-  notify: restart nginx
+  notify: reload nginx
 
 - name: put host port 443 configuration in sites-enabled
   file: src=/etc/nginx/sites-available/{{ nginx_conf_file_name }}.443.conf dest=/etc/nginx/sites-enabled/{{ nginx_conf_file_name }}.443 state=link
   when: nginx_cert.stat.exists == true and nginx_key.stat.exists == true
-  notify: restart nginx
+  notify: reload nginx
 
 - name: ensure nginx is running
   service: name=nginx state=started{%endraw%}


### PR DESCRIPTION
> Why was this change necessary?

While deploying code, we do not verify nginx config and try to reload straight away. This creates problems.

> How does it address the problem?

Before reloading nginx, we not have a hook to ensure nginx config is valid.

> Are there any side effects?

No
