### PR TITLE
Update bumpversion logic to make it simple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.10.x]
 
+- Use simplified bumpversion rules, remove requirement of intermediate release tags e.g. `0.1.0-dev`.
 - Add multiple environment support on a single machine (@theskumar)
 - Add .env.sample file (@theskumar)
 - Add django-flat-responsive to give django-admin a responsive touch (@theskumar)

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -63,10 +63,6 @@ if echo "$yn" | grep -iq "^y"; then
     echo "${green}==> Setup the project dependencies and database for local development${reset}"
     fab init
 
-    echo "==> Bumpversion 0.1.0-dev"
-    source venv/bin/activate
-    bumpversion --no-tag minor
-
     OUT=$?
     if [ $OUT -eq 0 ]; then
         echo "${green}============================================"

--- a/{{cookiecutter.github_repository}}/README.md
+++ b/{{cookiecutter.github_repository}}/README.md
@@ -44,8 +44,7 @@ Execute the following commands:
 ```
 git checkout master
 fab test
-bumpversion release
-bumpversion --no-tag patch # 'patch' can be replaced with 'minor' or 'major'
+bumpversion patch  # 'patch' can be replaced with 'minor' or 'major'
 git push origin master
 git push origin master --tags
 git checkout qa

--- a/{{cookiecutter.github_repository}}/setup.cfg
+++ b/{{cookiecutter.github_repository}}/setup.cfg
@@ -2,10 +2,6 @@
 current_version = {{ cookiecutter.version }}
 commit = True
 tag = True
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
-serialize =
-	{major}.{minor}.{patch}-{release}
-	{major}.{minor}.{patch}
 
 [bumpversion:file:{{ cookiecutter.main_module }}/__init__.py]
 


### PR DESCRIPTION
Use simplified bumpversion rules, remove requirement of intermediate release tags e.g. `0.1.0-dev`.