### PR TITLE
fix(settings/celery): update CELERY_BROKER_URL to properly respect REDIS_URL

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -309,11 +309,11 @@ REQUEST_ID_RESPONSE_HEADER = 'REQUEST_ID'
 # DJANGO CELERY CONFIGURATION
 # -----------------------------------------------------------------------------
 # see: http://celery.readthedocs.org/en/latest/userguide/tasks.html#task-states
-CELERY_BROKER_URL = "{0}/{1}".format(env('REDIS_URL', default="redis://localhost:6379"), 0)
+CELERY_BROKER_URL = env('REDIS_URL', default="redis://localhost:6379/0")
 CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
-CELERY_TIMEZONE = 'UTC'
+CELERY_TIMEZONE = env('CELERY_TIMEZONE', default=TIME_ZONE)  # Use django's timezone by default
 {%- endif %}
 
 # LOGGING CONFIGURATION


### PR DESCRIPTION
Redis database name should be provided in the .env and not hard-coded.