### PR TITLE
feat(exceptions): handle nested serializer errors in our exception handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.10.x]
 
+- Handle nested serializer errors in our custom exception handler. (@jainmickey)
 - Remove mock dependency, replace with standard unittest.mock library
 - Add default 'AUTH_PASSWORD_VALIDATORS' in settings
 - Add django-rest-swagger integration

--- a/{{cookiecutter.github_repository}}/docs/api/errors.md
+++ b/{{cookiecutter.github_repository}}/docs/api/errors.md
@@ -41,4 +41,36 @@ The response body will contain json in the format same as Generic Error with `fi
 }
 ```
 
+For nested errors:
+
+The response body will contain json in the format same as Validation error with `errors` as key. For example:
+
+```json
+{
+  "error_type": "ValidationError",
+  "errors": [
+    {
+      "field": "profile",
+      "message": null,
+      "errors": [
+        {
+          "field": "email",
+          "message": "User with this email address already exists."
+        },
+        {
+          "field": "custom_data",
+          "message": null,
+          "errors": [
+            {
+              "field": "age",
+              "message": "Person too young. Age should be more than 18 years."
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
 __NOTE__: The copy for most of these error messages can be changed by backend developers.

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/exceptions.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/exceptions.py
@@ -68,6 +68,35 @@ class NotAuthenticated(exceptions.NotAuthenticated):
     pass
 
 
+def parse_field_errors(field, error_msg, depth=0):
+    # We only parse errors upto 10 nested serializers
+    if depth is not None:
+        assert depth >= 0, "'depth' may not be negative."
+        assert depth <= 10, "'depth' may not be greater than 10."
+
+    errors = []
+
+    if isinstance(error_msg, dict):
+        for error_msg_key, error_msg_values in list(error_msg.items()):
+            for msg in error_msg_values:
+                errors.append(
+                    {
+                        'field': field,
+                        'message': None,
+                        'errors': parse_field_errors(error_msg_key, msg, depth=depth + 1)
+                    }
+                )
+    else:
+        errors.append(
+            {
+                'field': field,
+                'message': error_msg,
+            }
+        )
+
+    return errors
+
+
 def format_exception(exc):
     class_name = exc.__class__.__name__
     detail = {
@@ -85,12 +114,7 @@ def format_exception(exc):
                         }
                     )
                 else:
-                    detail['errors'].append(
-                        {
-                            'field': error_key,
-                            'message': error_msg,
-                        }
-                    )
+                    detail['errors'] = detail['errors'] + parse_field_errors(error_key, error_msg)
     elif isinstance(exc.detail, list):
         for error_msg in exc.detail:
             detail['errors'].append(


### PR DESCRIPTION
fix #234 

> Why was this change necessary?

Currently the custom exception handler does not parse the nested serializer errors properly.

> How does it address the problem?

It will parse the nested serializer errors upto 10 level depth as DRF supports maximum 10 depth.

> Are there any side effects?

No

