### PR TITLE
fix(nginx/letsencrypt): ensure nginx is reloaded after renewal of cert

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
@@ -19,7 +19,7 @@
 
 # running cron job each monday
 - name: add letsencrypt renew cron
-  cron: name="Renew all certificates" minute="0" hour="2" weekday="1" job="PATH=$PATH:/usr/local/bin && certbot-auto renew --non-interactive --webroot -w {{ letsencrypt_challange_root }}  >> /var/log/certbot.log && service nginx reload"
+  cron: name="Renew all certificates" minute="0" hour="2" weekday="1" job="PATH=$PATH:/usr/local/bin && certbot-auto renew --non-interactive --webroot -w {{ letsencrypt_challange_root }} --renew-hook 'service nginx reload' >> /var/log/certbot.log"
   when: vm == 0 and use_letsencrypt
 
 - name: check ssl/nginx.crt exists


### PR DESCRIPTION
> Why was this change necessary?

nginx doesn't get reloaded reliably. 

> How does it address the problem?

Use '--renew-hook' instead of shell chaining, which might fail due to wrong
exit code from "certbot-auto" command

> Are there any side effects?

None.
