### PR TITLE
fix(requirements): remove duplicate requirement

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -29,6 +29,7 @@ psycopg2==2.7.1
 Pillow==4.2.0
 django-extensions==1.8.0
 django-uuid-upload-path==1.0.0
+django-versatileimagefield==1.7.1  # versatile image field degrade Pillow version to 4.0.0
 
 # REST APIs
 # -------------------------------------

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -13,7 +13,6 @@ devrecargar==0.1.4
 # -------------------------------------
 django-debug-toolbar==1.8
 ipdb==0.10.3
-django-extensions==1.7.9  # for shell_plus and other utils
 
 # Testing and coverage
 # -------------------------------------


### PR DESCRIPTION
> Why was this change necessary?

Duplicate entry in common and development files.
Versatileimagefield added to requirements as it is being used in base imagemixin.

> How does it address the problem?

Removes the older version from development file.

> Are there any side effects?
no

fixes #243 