### PR TITLE
enable http2

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
@@ -1,4 +1,4 @@
-ngnix_listen: '443 ssl'
+ngnix_listen: '443 http2 ssl'
 nginx_user: 'www-data'
 nginx_worker_processes: 1
 nginx_worker_connections: 1024


### PR DESCRIPTION
nginx above 1.9 supports http2 by default, this is required to enable the same.

> Why was this change necessary?

enhancement. http2 among other things, makes only one request to the server reducing the overhead of multiple calls. 

though minor will effect the performance of the application.

> How does it address the problem?

enables http2

> Are there any side effects?

browsers that do not support http2 will be able to work with http1.1, so no side effects.
