### PR TITLE
settings: make putting up ALLOWED_HOSTS compulsory in production

### DIFF
--- a/{{cookiecutter.github_repository}}/.env.sample
+++ b/{{cookiecutter.github_repository}}/.env.sample
@@ -8,6 +8,7 @@
 # SITE_SCHEME=https
 # SITE_DOMAIN=youdomain.com
 # SITE_NAME='your site name'
+# ALLOWED_HOSTS=youdomain.com
 # DJANGO_SECURE_HSTS_SECONDS=60
 
 # Databases

--- a/{{cookiecutter.github_repository}}/docs/backend/server_config.md
+++ b/{{cookiecutter.github_repository}}/docs/backend/server_config.md
@@ -65,6 +65,7 @@ heroku config:set NEW_RELIC_APP_NAME=<new-relic-app-name> --app=<heroku-app-name
 heroku config:set DJANGO_SETTINGS_MODULE='settings.production' \
 DJANGO_SECRET_KEY=`openssl rand -hex 64` \
 SITE_DOMAIN=<heroku-app-name>.herokuapp.com \
+ALLOWED_HOSTS=<heroku-app-name>.herokuapp.com \
 SITE_SCHEME=https \
 SITE_NAME=DJANGO_SITE_NAME_HERE --app=<heroku-app-name>
 

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -22,8 +22,8 @@ from .common import (DATABASES, INSTALLED_APPS, {% if cookiecutter.add_django_au
 # SITE CONFIGURATION
 # Hosts/domain names that are valid for this site.
 # "*" matches anything, ".example.com" matches example.com and all subdomains
-# See https://docs.djangoproject.com/en/1.5/ref/settings/#allowed-hosts
-ALLOWED_HOSTS = ['*']
+# See https://docs.djangoproject.com/en/1.11/ref/settings/#allowed-hosts
+ALLOWED_HOSTS = env.list('ALLOWED_HOSTS')
 
 SITE_SCHEME = env('SITE_SCHEME', default='https')
 


### PR DESCRIPTION
> Why was this change necessary?

The default config is too permissive with `*`. Leading to people forget adding ALLOWED_HOSTS often. 

> How does it address the problem?

It will raise a `ImproperlyConfigured` like many other settings already does already and server will refuse to star.

> Are there any side effects?

Nope, just requires one time putting up ALLOWED_HOSTS during server setup.
