### PR TITLE
uwsgi: Ignore os write errors in django-uwsgi

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/django.uwsgi.ini.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/django.uwsgi.ini.j2
@@ -24,3 +24,10 @@ no-orphans=true
 chmod-socket=660
 log-date=true
 logto = {{project_log_dir}}/uwsgi.log{% endraw %}
+
+
+# os write errors
+# https://github.com/getsentry/raven-python/issues/732#issuecomment-176854438
+ignore-sigpipe = true
+ignore-write-errors = true
+disable-write-exception = true


### PR DESCRIPTION
These errors occur when network connection is abruptly dropped by
nginx(by browser)  and uwsgi hasn't yet responded.

Sentry catches them as uwsgi raises. We don't need this error level

> Why was this change necessary?

add your text here...

> How does it address the problem?

add your text here...

> Are there any side effects?

add your text here...
