### PR TITLE
Add automatic documentation build when using ansible and make it available at `/docs/` urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.10.x]
 
+- Add automatic documentation build when using ansible and make it available at `/docs/` url.
 - Handle nested serializer errors in our custom exception handler. (@jainmickey)
 - Remove mock dependency, replace with standard unittest.mock library
 - Add `django-cors-headers` integration (@jainmickey)

--- a/{{cookiecutter.github_repository}}/fabfile.py
+++ b/{{cookiecutter.github_repository}}/fabfile.py
@@ -183,10 +183,14 @@ def deploy():
 
 
 def deploy_docs():
+    """Deploy documentation to server via ansible.
+    """
     configure(tags='documentation', skip_tags=''){% else %}
 
 
 def deploy_docs():
+    """Deploy documentation to github pages.
+    """
     with fab.lcd(HERE) and virtualenv():
         local('mkdocs gh-deploy')
         local('rm -rf _docs_html'){% endif %}

--- a/{{cookiecutter.github_repository}}/fabfile.py
+++ b/{{cookiecutter.github_repository}}/fabfile.py
@@ -56,12 +56,6 @@ def serve_docs(options=''):
         local('mkdocs serve {}'.format(options))
 
 
-def deploy_docs():
-    with fab.lcd(HERE) and virtualenv():
-        local('mkdocs gh-deploy')
-        local('rm -rf _docs_html')
-
-
 def shell():
     manage('shell_plus')
 
@@ -185,7 +179,17 @@ def configure(tags='', skip_tags='deploy'):
 
 
 def deploy():
-    configure(tags='deploy', skip_tags=''){% endif %}
+    configure(tags='deploy', skip_tags='')
+
+
+def deploy_docs():
+    configure(tags='documentation', skip_tags=''){% else %}
+
+
+def deploy_docs():
+    with fab.lcd(HERE) and virtualenv():
+        local('mkdocs gh-deploy')
+        local('rm -rf _docs_html'){% endif %}
 
 
 # Helpers

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
@@ -38,6 +38,10 @@ server {
     }
     {% endif %}
 
+    location /docs {
+        alias {{ project_path }}/_docs_html/;
+    }
+
     # Setup named location for Django requests and handle proxy details
     location / {
         uwsgi_pass unix:///tmp/django-{{ domain_name }}-uwsgi.sock;

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
@@ -39,6 +39,7 @@ server {
     {% endif %}
 
     location /docs {
+        # mkdocs html generated via "product_data" role
         alias {{ project_path }}/_docs_html/;
     }
 

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
@@ -68,7 +68,6 @@
   args:
     chdir: "{{ project_path }}"
   become: false
-  when: gitresult.changed
   tags: ['deploy', 'documentation']
 
 - name: copy uwsgi configuration

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
@@ -63,6 +63,14 @@
   tags: ['deploy']
 #  notify: reload celery  ## Uncomment this when project is using celery
 
+- name: Build documentation for "/docs" url.
+  command: "{{ venv_path }}/bin/mkdocs build"
+  args:
+    chdir: "{{ project_path }}"
+  become: false
+  when: gitresult.changed
+  tags: ['deploy', 'documentation']
+
 - name: copy uwsgi configuration
   template: src=django.uwsgi.ini.j2
             dest={{ uwsgi_conf_path }}//django-{{project_name}}-{{ environment }}.ini

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -51,6 +51,10 @@ django-compressor-autoprefixer==0.1.0
 # -------------------------------------
 django-log-request-id==1.3.2
 
+# Documentation
+# -------------------------------------
+mkdocs==0.16.3
+
 {% if cookiecutter.use_sentry_for_error_reporting == "y" -%}
 # Raven is the Sentry client
 # --------------------------

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -2,7 +2,6 @@
 
 # Documentation
 # -------------------------------------
-mkdocs==0.16.3
 isort==4.2.15
 
 # Livereload


### PR DESCRIPTION
> Why was this change necessary?

Keeps the documentation in sync with the codebase deployed on each of the environment. Also there is no need to deploy the docs separately. Now, if using ansible/nginx setup, the docs are available at `/docs` url for each of the domain. 

> How does it address the problem?

Documentation sometimes remain outdated. It's hard to know, what deployed on dev vs qa vs production environment. Now, by visiting at the `/docs/` url of each environment, it possible to know what deployed and what's not.

> Are there any side effects?

The old deployment on gh-pages, is still possible with `mkdocs gh-pages`, and if not using ansible, `fab deploy_docs` works the old way. 
