### PR TITLE
nginx: enable ipv6 support

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
@@ -2,6 +2,7 @@
 
 server {
     listen       {{ ngnix_listen }};
+    listen       [::]:{{ ngnix_listen }};
     server_name  {{ domain_name }};
 
     ssl on;

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.80.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.80.conf.j2
@@ -1,6 +1,7 @@
 {%raw%}# {{ ansible_managed }}
 server {
     listen       80;
+    listen       [::]:80;
     server_name  {{ domain_name }};
 
     {% if use_letsencrypt %}


### PR DESCRIPTION
> Why was this change necessary?

Add present the servers doesn't listen if the server IP is IPv6. 

> How does it address the problem?

Support of IPv6 enabled in nginx which is the top-level proxy for all the incoming requests to server.

> Are there any side effects?

nope
