### PR TITLE
nginx: enable ngx_http_charset_module to add default utf-8 encoding to content-type headers

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/nginx.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/nginx.conf.j2
@@ -13,6 +13,7 @@ http {
     # Basic Settings
     # --------------------------------------
 
+    charset         utf-8;
     sendfile on;
     tcp_nopush on;
     tcp_nodelay on;


### PR DESCRIPTION
> Why was this change necessary?

Missing encoding info in the responses.

> How does it address the problem?

The ngx_http_charset_module module adds the specified charset to the “Content-Type” response header field. In addition, the module can convert data from one charset to another, with some limitations:

- conversion is performed one way — from server to client,
- only single-byte charsets can be converted
- or single-byte charsets to/from UTF-8.

https://nginx.org/en/docs/http/ngx_http_charset_module.html

> Are there any side effects?

If the application is intensionally has different encoding that utf-8, then this value should be changed to reflect that. 
