### PR TITLE
fix(celery): celery beat scheduler issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.10.x]
 
+- Fixes celery beat scheduler issue & makes celery role consistent across deployments. (@CuriousLearner)
 - Add automatic documentation build when using ansible and make it available at `/docs/` url.
 - Handle nested serializer errors in our custom exception handler. (@jainmickey)
 - Remove mock dependency, replace with standard unittest.mock library

--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/defaults/main.yml
@@ -5,5 +5,7 @@ celery_concurrency: 4
 celery_log_dir: /var/log/celery/{{ project_namespace }}
 celery_log_file: "{{ celery_log_dir }}/celery.log"
 celery_log_level: "INFO"
+celerybeat_schedule_dir: /var/run/celery
+celerybeat_schedule_file: "{{ celerybeat_schedule_dir }}/schedule-{{ project_namespace }}.db"
 celery_pid_file: /tmp/celery-{{ project_namespace }}.pid
 {% endraw %}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/tasks/main.yml
@@ -14,6 +14,10 @@
   become: false
   tags: ['celery']
 
+- name: make sure celerybeat schedule directory exists
+  file: path={{ celerybeat_schedule_dir }} state=directory owner={{celery_user}} group={{celery_group}} mode=751 recurse=yes
+  tags: ['configure', 'celery']
+
 - name: ensure celery package is installed
   pip: name=celery state=present executable={{ venv_path }}/bin/pip
   tags: ['celery']

--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/templates/celery.service.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/templates/celery.service.j2
@@ -9,10 +9,10 @@ Type=forking
 Restart=always
 WorkingDirectory={{ project_path }}
 ExecStart={{ venv_path }}/bin/celery multi start worker-{{ project_namespace }} -A {{ project_name }} -B -l {{ celery_log_level }} \
-    --concurrency={{ celery_concurrency }} --logfile={{ celery_log_file }} --pidfile={{ celery_pid_file }}
+    --concurrency={{ celery_concurrency }} --logfile={{ celery_log_file }} --pidfile={{ celery_pid_file }}  --schedule={{ celerybeat_schedule_file}}
 ExecStop={{ venv_path }}/bin/celery multi stopwait worker-{{ project_namespace }} --pidfile={{ celery_pid_file }}
 ExecReload={{ venv_path }}/bin/celery multi restart worker-{{ project_namespace }} -A {{ project_name }} -B -l {{ celery_log_level }} \
-    --concurrency={{ celery_concurrency }} --logfile={{ celery_log_file }} --pidfile={{ celery_pid_file }}
+    --concurrency={{ celery_concurrency }} --logfile={{ celery_log_file }} --pidfile={{ celery_pid_file }}  --schedule={{ celerybeat_schedule_file}}
 
 [Install]
 WantedBy=multi-user.target

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
@@ -61,7 +61,6 @@
   django_manage: command=migrate app_path={{ project_path }} virtualenv={{ venv_path }}
   become: false
   tags: ['deploy']
-#  notify: reload celery  ## Uncomment this when project is using celery
 
 - name: Build documentation for "/docs" url.
   command: "{{ venv_path }}/bin/mkdocs build"
@@ -83,3 +82,6 @@
   when: not uwsgiconf.changed
   tags: ['deploy']
 {% endraw %}
+  {%- if cookiecutter.add_celery.lower() == 'y' %}
+    notify: reload celery  # reload celery everytime uwsgi conf changes
+  {%- endif %}

--- a/{{cookiecutter.github_repository}}/provisioner/site.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/site.yml
@@ -33,8 +33,13 @@
     - nginx
     - postgresql
     - project_data
+{%- if cookiecutter.add_celery.lower() == 'y' %}
+    - redis
+    - celery
+{%- else %}
     # - redis
     # - celery
+{%- endif %}
 
 #= QA
 #===================================================
@@ -50,8 +55,13 @@
     - nginx
     - project_data
     - postgresql
+{%- if cookiecutter.add_celery.lower() == 'y' %}
+    - redis
+    - celery
+{%- else %}
     # - redis
     # - celery
+{%- endif %}
 
 #= Production
 #===================================================


### PR DESCRIPTION
> Why was this change necessary?

Fixes celery beat schedule file path on servers.

Also makes celery roles consistent in provisioner across deployments.

> How does it address the problem?

Currently, scheduler file is spawned in the source code dir. This poses problems on server, since we only want to give read access to the source code.
The PR separates out the schedule file to a separate dir where the state of tasks is maintained.

> Are there any side effects?

None.
