### PR TITLE
fix(settings): make s3 region default null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Replace gunicorn with uwsgi as wsgi handler (@vikalpj)
 
 ### Fixes
+- Make default s3 region null.
 - RemovedInDjango20Warning: Update admin url to new style url include (@theskumar)
 - RemovedInDjango20Warning: Use new-style MIDDLEWARE settings (@theskumar)
 - Fix letsencrtypt, make certbot-auto run in non-interactive mode.

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -99,7 +99,7 @@ if ENABLE_MEDIA_UPLOAD_TO_S3:
     AWS_STORAGE_BUCKET_NAME = env('DJANGO_AWS_STORAGE_BUCKET_NAME')
     AWS_QUERYSTRING_AUTH = False
     AWS_S3_HOST = env('DJANGO_AWS_S3_HOST', default='')
-    AWS_S3_REGION_NAME = env('DJANGO_AWS_S3_REGION_NAME', default='')
+    AWS_S3_REGION_NAME = env('DJANGO_AWS_S3_REGION_NAME', default=None)
 
     # AWS cache settings, don't change unless you know what you're doing.
     AWS_EXPIRY = 60 * 60 * 24 * 7  # 1 week


### PR DESCRIPTION
- 

> Why was this change necessary?

Empty region generate error in s3 url.

> How does it address the problem?

Null region avoid region configuration in S3 url.

> Are there any side effects?

No
