### PR TITLE
fix(ansible): add official nginx and certbot repo and configuration

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/tasks/main.yml
@@ -20,6 +20,7 @@
 
 - name: ensure celery package is installed
   pip: name=celery state=present executable={{ venv_path }}/bin/pip
+  become: false
   tags: ['celery']
 
 - name: copy celery service

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
@@ -6,9 +6,24 @@ nginx_max_file_size: 10
 
 {% raw %}
 nginx_conf_file_name: '{{ project_name }}-{{ environment }}'
+
+# SSL common configurations
 ssl_cert_dir: '/etc/nginx/ssl'
 ssl_forward_secrecy_key_path: /etc/nginx/dhparam.pem
 ssl_forward_secrecy_key_length: 2048
 letsencrypt_ssl_cert_dir: '/etc/letsencrypt/live/{{ domain_name }}'
 letsencrypt_challange_root: '/app/certbot'
-letsencrypt_email: 'webmaster@{{ domain_name }}'{% endraw %}
+letsencrypt_email: 'webmaster@{{ domain_name }}'
+ssl_certificate: '{{ ssl_cert_dir }}/{{ domain_name }}/fullchain.pem'
+ssl_certificate_key: '{{ ssl_cert_dir }}/{{ domain_name }}/privkey.pem'
+ssl_dhparam: '{{ ssl_forward_secrecy_key_path }}'
+
+# Oldest compatible clients: Firefox 1, Chrome 1, IE 7, Opera 5, Safari 1, Windows XP IE8, Android 2.3, Java 7
+ssl_protocols: 'TLSv1 TLSv1.1 TLSv1.2'
+ssl_ciphers: 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS'
+ssl_session_timeout: '1d'
+ssl_session_cache: 'shared:SSL:50m'
+ssl_trusted_certificate: '{{ ssl_cert_dir }}/{{ domain_name }}/chain.pem'
+access_log_file: '/var/log/nginx/{{ domain_name }}.access.log'
+error_log_file: '/var/log/nginx/{{ domain_name }}.error.log'
+client_max_body_size: '{{ nginx_max_file_size }}'{% endraw %}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/letsencrypt.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/letsencrypt.yml
@@ -7,16 +7,15 @@
     - libaugeas0
     - libffi-dev
 
-- name: install certbot auto
-  get_url:
-    url: https://dl.eff.org/certbot-auto
-    dest: /usr/local/bin
+- name: Add official Certbot repo
+  apt_repository:
+    repo: 'ppa:certbot/certbot'
+    update_cache: yes
 
-- name: make certbot executable
-  file:
-    path: /usr/local/bin/certbot-auto
-    mode: a+x
-    state: file
+- name: install certbot
+  apt:
+    pkg: python-certbot-nginx
+    state: installed
 
 - name: create certbot folder
   become: yes
@@ -37,7 +36,7 @@
   service: name=nginx state=stopped
 
 - name: request cert
-  shell: certbot-auto certonly --standalone -w {{ letsencrypt_challange_root }} -d {{ domain_name }} --email {{ letsencrypt_email }} --agree-tos
+  shell: certbot certonly --standalone -w {{ letsencrypt_challange_root }} -d {{ domain_name }} --email {{ letsencrypt_email }} --agree-tos --non-interactive
   args:
     creates: '{{ letsencrypt_ssl_cert_dir }}'
 

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
@@ -1,11 +1,11 @@
 {%raw%}---
-- name: Update apt-cache if not already ran
-  shell: apt update
-  become: yes
-  when: apt_updated is not defined
+- name: Add official Nginx repo
+  apt_repository:
+    repo: 'ppa:nginx/stable'
+    update_cache: yes
 
 - name: install NGINX Server.
-  apt: pkg=nginx state=installed
+  apt: pkg=nginx-full state=installed
 
 - name: make sure ssl directory exists
   file: path={{ ssl_cert_dir }} state=directory
@@ -19,7 +19,12 @@
 
 # running cron job each monday
 - name: add letsencrypt renew cron
-  cron: name="Renew all certificates" minute="0" hour="2" weekday="1" job="PATH=$PATH:/usr/local/bin && certbot-auto renew --non-interactive --webroot -w {{ letsencrypt_challange_root }} --renew-hook 'service nginx reload' >> /var/log/certbot.log"
+  cron:
+   name: "Renew all certificates"
+   minute: "0"
+   hour: "2"
+   weekday: "1"
+   job: 'certbot renew --non-interactive --webroot -w {{ letsencrypt_challange_root }} --renew-hook "service nginx reload"'
   when: vm == 0 and use_letsencrypt
 
 - name: check ssl/nginx.crt exists

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
@@ -6,17 +6,17 @@ server {
     server_name  {{ domain_name }};
 
     ssl on;
-    ssl_certificate     {{ ssl_cert_dir }}/{{ domain_name }}/fullchain.pem;
-    ssl_certificate_key {{ ssl_cert_dir }}/{{ domain_name }}/privkey.pem;
-    ssl_dhparam         {{ ssl_forward_secrecy_key_path }};
+    ssl_certificate     {{ ssl_certificate }};
+    ssl_certificate_key {{ ssl_certificate_key }};
+    ssl_dhparam         {{ ssl_dhparam }};
 
-    # Oldest compatible clients: Firefox 1, Chrome 1, IE 7, Opera 5, Safari 1, Windows XP IE8, Android 2.3, Java 7
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
+
+    ssl_protocols {{ ssl_protocols }};
+    ssl_ciphers '{{ ssl_ciphers }}';
     ssl_prefer_server_ciphers on;
 
-    ssl_session_timeout 1d;
-    ssl_session_cache shared:SSL:50m;
+    ssl_session_timeout {{ ssl_session_timeout }};
+    ssl_session_cache {{ ssl_session_cache }};
     ssl_session_tickets off;
 
     # OCSP Stapling ---
@@ -25,12 +25,14 @@ server {
     ssl_stapling_verify on;
 
     ## verify chain of trust of OCSP response using Root CA and Intermediate certs
-    ssl_trusted_certificate {{ ssl_cert_dir }}/{{ domain_name }}/chain.pem;
+    ssl_trusted_certificate {{ ssl_trusted_certificate }};
 
-    access_log   /var/log/nginx/{{ domain_name }}.access.log;
-    error_log    /var/log/nginx/{{ domain_name }}.error.log;
 
-    client_max_body_size {{ nginx_max_file_size }}M;
+    access_log   {{ access_log_file }};
+    error_log    {{ error_log_file }};
+
+
+    client_max_body_size {{ client_max_body_size}};
 
     {% if use_letsencrypt %}
     location /.well-known/acme-challenge {


### PR DESCRIPTION
- Install nginx full
- Move nginx configuration to variables to avoid duplication
- Use certbot instead of certbot-auto
- make celery installation without sudo

> Why was this change necessary?

Fix nginx reload issue after letsencrypt renew job.

> How does it address the problem?

Changed the renew job and use the official certbot configuration.

> Are there any side effects?

No
