### PR TITLE
feat(logging): Add Error level logging to sentry mails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.10.x]
 
+- Adds `ERROR` level logging to sentry mails. (@CuriousLearner)
 - Fixes celery beat scheduler issue & makes celery role consistent across deployments. (@CuriousLearner)
 - Add automatic documentation build when using ansible and make it available at `/docs/` url.
 - Handle nested serializer errors in our custom exception handler. (@jainmickey)

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -377,7 +377,15 @@ LOGGING = {
             'level': 'ERROR',
             'filters': ['require_debug_false'],
             'class': 'django.utils.log.AdminEmailHandler'
-        }
+        },
+        {%- if cookiecutter.use_sentry_for_error_reporting == 'y' %}
+        'sentry': {
+            'level': 'ERROR',
+            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+            'formatter': 'complete',
+            'filters': ['request_id'],
+        },
+        {%- endif %}
     },
     'loggers': {
         'django': {
@@ -402,7 +410,12 @@ LOGGING = {
         },
         # Catch All Logger -- Captures any other logging
         '': {
-            'handlers': ['console'],
+            'handlers': [
+                'console',
+                {%- if cookiecutter.use_sentry_for_error_reporting == 'y' %}
+                'sentry'
+                {%- endif %}
+            ],
             'level': 'ERROR',
             'propagate': True,
         },


### PR DESCRIPTION
> Why was this change necessary?

At this point only Exceptions are captured by Sentry. It would be good idea to capture `ERROR` logs too.

> How does it address the problem?

Capture `ERROR` level logs for Sentry.

> Are there any side effects?

None.
