### PR TITLE
Add support for static type hinting check via flake8-mypy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Icon
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+.mypy_cache/
 
 # C extensions
 *.so

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -19,7 +19,7 @@ pytest-django==3.1.2
 pytest-pythonpath==0.7.1
 pytest-cov==2.5.1
 django-dynamic-fixture==1.9.5
-flake8==3.4.1
+flake8-mypy==17.8.0
 
 # Versioning
 # -------------------------------------

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/models.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/models.py
@@ -15,7 +15,7 @@ from {{cookiecutter.main_module}}.base.models import UUIDModel
 class UserManager(BaseUserManager):
     use_in_migrations = True
 
-    def _create_user(self, email, password, is_staff, is_superuser, **extra_fields):
+    def _create_user(self, email: str, password: str, is_staff: bool, is_superuser: bool, **extra_fields):
         """Creates and saves a User with the given email and password.
         """
         email = self.normalize_email(email)
@@ -25,10 +25,10 @@ class UserManager(BaseUserManager):
         user.save(using=self._db)
         return user
 
-    def create_user(self, email, password=None, **extra_fields):
+    def create_user(self, email: str, password=None, **extra_fields):
         return self._create_user(email, password, False, False, **extra_fields)
 
-    def create_superuser(self, email, password, **extra_fields):
+    def create_superuser(self, email: str, password: str, **extra_fields):
         return self._create_user(email, password, True, True, **extra_fields)
 
 
@@ -57,13 +57,13 @@ class User(AbstractBaseUser, UUIDModel, PermissionsMixin):
     def __str__(self):
         return str(self.id)
 
-    def get_full_name(self):
+    def get_full_name(self) -> str:
         """Returns the first_name plus the last_name, with a space in between.
         """
         full_name = '{} {}'.format(self.first_name, self.last_name)
         return full_name.strip()
 
-    def get_short_name(self):
+    def get_short_name(self) -> str:
         """Returns the short name for the user.
         """
         return self.first_name.strip()


### PR DESCRIPTION
> Why was this change necessary?

We use python 3 and flake8 currently breaks with static hinting syntax in python 3 code.

> How does it address the problem?

Use flake8-mypy drop-in plugin for flake8 to add support for mypy checks.

> Are there any side effects?

🙅‍♂️ 
