### PR TITLE
feat(.travis.yml): Removes pip-accel

### DIFF
--- a/{{cookiecutter.github_repository}}/.travis.yml
+++ b/{{cookiecutter.github_repository}}/.travis.yml
@@ -12,15 +12,13 @@ addons:
 cache:
   directories:
     - $HOME/.cache/pip
-    - $HOME/.pip-accel
 
 before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log
 
 install:
-  - pip install pip-accel
-  {% if cookiecutter.add_ansible.lower() == 'y' %}- pip-accel install ansible{% endif %}
-  - pip-accel install -r requirements/development.txt
+  {% if cookiecutter.add_ansible.lower() == 'y' %}- pip install ansible{% endif %}
+  - pip install -r requirements/development.txt
 
 before_script:
 - export DATABASE_URL=postgres://postgres@localhost/{{ cookiecutter.main_module }}


### PR DESCRIPTION
> Why was this change necessary?

Travis builds are failing. `pip-accel` is not needed. We can just use `pip`.

> How does it address the problem?

Travis builds no longer fails.

> Are there any side effects?

None.
