### PR TITLE
update postgresql, add postgis addon and remove pip accel

### DIFF
--- a/{{cookiecutter.github_repository}}/.travis.yml
+++ b/{{cookiecutter.github_repository}}/.travis.yml
@@ -7,7 +7,10 @@ python:
 - '3.5.2'
 
 addons:
-  postgresql: "9.4"
+  postgresql: "9.5"
+  apt:
+    packages:
+      - postgresql-9.5-postgis-2.3
 
 cache:
   directories:


### PR DESCRIPTION
> Why was this change necessary?

Postgis addon not included with new travis environment and pip accel was causing issue with ansible installation

> How does it address the problem?

added postgis addon installation and removed pip accel as pip is fast now

> Are there any side effects?

No
