### PR TITLE
chore(users/services.py): removed unused import

### DIFF
--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/services.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/services.py
@@ -1,5 +1,4 @@
 # Third Party Stuff
-from django.conf import settings
 from django.contrib.auth import get_user_model, authenticate
 
 # {{ cookiecutter.project_name }} Stuff


### PR DESCRIPTION
> Why was this change necessary?

The unused import causes flake8 error during the dev CI testing
> How does it address the problem?

By removing the unused import CI and other test run fine. 

> Are there any side effects?

Nothing since I haven't encountered anything. 

