### PR TITLE
Renamed environment var to deploy_environment

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/hosts
+++ b/{{cookiecutter.github_repository}}/provisioner/hosts
@@ -3,8 +3,8 @@
 
 [vagrant:vars]
 vm=1
-environment=vagrant
-project_namespace={% raw %}{{ project_name }}-{{ environment }}{% endraw %}
+deploy_environment=vagrant
+project_namespace={% raw %}{{ project_name }}-{{ deploy_environment }}{% endraw %}
 user=vagrant
 project_path=/home/vagrant/{{ cookiecutter.github_repository }}
 venv_path=/home/vagrant/venv
@@ -21,11 +21,11 @@ dev.{{ cookiecutter.main_module }}.com
 
 [dev:vars]
 vm=0
-environment=dev
+deploy_environment=dev
 user=ubuntu
-project_namespace={% raw %}{{ project_name }}-{{ environment }}{% endraw %}
-project_path=/home/ubuntu/{% raw %}{{ environment }}{% endraw %}/{{ cookiecutter.github_repository }}
-venv_path=/home/ubuntu/{% raw %}{{ environment }}/{{ project_name }}-venv{% endraw %}
+project_namespace={% raw %}{{ project_name }}-{{ deploy_environment }}{% endraw %}
+project_path=/home/ubuntu/{% raw %}{{ deploy_environment }}{% endraw %}/{{ cookiecutter.github_repository }}
+venv_path=/home/ubuntu/{% raw %}{{ deploy_environment }}/{{ project_name }}-venv{% endraw %}
 use_letsencrypt={{ 'True' if cookiecutter.letsencrypt.lower() == 'y' else 'False' }}
 letsencrypt_email={{ cookiecutter.letsencrypt_email }}
 django_requirements_file=requirements.txt
@@ -38,11 +38,11 @@ qa.{{ cookiecutter.main_module }}.com
 
 [qa:vars]
 vm=0
-environment=qa
+deploy_environment=qa
 user=ubuntu
-project_namespace={% raw %}{{ project_name }}-{{ environment }}{% endraw %}
-project_path=/home/ubuntu/{% raw %}{{ environment }}{% endraw %}/{{ cookiecutter.github_repository }}
-venv_path=/home/ubuntu/{% raw %}{{ environment }}/{{ project_name }}-venv{% endraw %}
+project_namespace={% raw %}{{ project_name }}-{{ deploy_environment }}{% endraw %}
+project_path=/home/ubuntu/{% raw %}{{ deploy_environment }}{% endraw %}/{{ cookiecutter.github_repository }}
+venv_path=/home/ubuntu/{% raw %}{{ deploy_environment }}/{{ project_name }}-venv{% endraw %}
 use_letsencrypt={{ 'True' if cookiecutter.letsencrypt.lower() == 'y' else 'False' }}
 letsencrypt_email={{ cookiecutter.letsencrypt_email }}
 django_requirements_file=requirements.txt
@@ -54,11 +54,11 @@ domain_name=qa.{{ cookiecutter.main_module }}.com
 
 [production:vars]
 vm=0
-environment=prod
+deploy_environment=prod
 user=ubuntu
-project_namespace={% raw %}{{ project_name }}-{{ environment }}{% endraw %}
-project_path=/home/ubuntu/{% raw %}{{ environment }}{% endraw %}/{{ cookiecutter.github_repository }}
-venv_path=/home/ubuntu/{% raw %}{{ environment }}/{{ project_name }}-venv{% endraw %}
+project_namespace={% raw %}{{ project_name }}-{{ deploy_environment }}{% endraw %}
+project_path=/home/ubuntu/{% raw %}{{ deploy_environment }}{% endraw %}/{{ cookiecutter.github_repository }}
+venv_path=/home/ubuntu/{% raw %}{{ deploy_environment }}/{{ project_name }}-venv{% endraw %}
 use_letsencrypt={{ 'True' if cookiecutter.letsencrypt.lower() == 'y' else 'False' }}
 letsencrypt_email={{ cookiecutter.letsencrypt_email }}
 django_requirements_file=requirements.txt

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
@@ -5,7 +5,7 @@ nginx_worker_connections: 1024
 nginx_client_max_body_size: '10M'
 
 {% raw %}
-nginx_conf_file_name: '{{ project_name }}-{{ environment }}'
+nginx_conf_file_name: '{{ project_name }}-{{ deploy_environment }}'
 
 # SSL common configurations
 ssl_cert_dir: '/etc/nginx/ssl'

--- a/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 pg_hstore: False
 pg_gis: False
-pg_db: '{% raw %}{{ project_name }}-{{ environment }}{% endraw %}'
+pg_db: '{% raw %}{{ project_name }}-{{ deploy_environment }}{% endraw %}'
 pg_user: dev
 pg_password: password

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/defaults/main.yml
@@ -1,6 +1,6 @@
 {% raw %}---
 pg_hstore: False
-pg_db: '{{ project_name }}-{{ environment }}'
+pg_db: '{{ project_name }}-{{ deploy_environment }}'
 pg_user: dev
 pg_password: password
 django_requirements_file: requirements.txt
@@ -18,4 +18,4 @@ uwsgi_conf_path: /etc/uwsgi-emperor/vassals
 uwsgi_socket: /tmp/django-{{ domain_name }}-uwsgi.sock
 uwsgi_pid_file: /tmp/django-{{ domain_name }}-wsgi.pid
 
-project_log_dir: /var/log/django/{{ environment }}/{{ project_name}}{% endraw %}
+project_log_dir: /var/log/django/{{ deploy_environment }}/{{ project_name}}{% endraw %}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: copy django-uwsgi logrotate
   template: src=django.logrotate.j2
-            dest=/etc/logrotate.d/uwsgi-{{ environment}}-{{project_name}}-django
+            dest=/etc/logrotate.d/uwsgi-{{ deploy_environment}}-{{project_name}}-django
             mode=644
   tags: ['configure']
 
@@ -71,7 +71,7 @@
 
 - name: copy uwsgi configuration
   template: src=django.uwsgi.ini.j2
-            dest={{ uwsgi_conf_path }}//django-{{project_name}}-{{ environment }}.ini
+            dest={{ uwsgi_conf_path }}//django-{{project_name}}-{{ deploy_environment }}.ini
             mode=644
   tags: ['deploy']
   register: uwsgiconf


### PR DESCRIPTION
> Why was this change necessary?

`environment` as a var name is restricted in ansible.
http://docs.ansible.com/ansible/latest/playbooks_variables.html#magic-variables-and-how-to-access-information-about-other-hosts

> How does it address the problem?

Renamed the environment var to deploy_environment

> Are there any side effects?

No.
