### PR TITLE
fixing pep8 W391 blank line at end of file in user app

### DIFF
--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/__init__.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/__init__.py
@@ -1,0 +1,1 @@
+# user app

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/__init__.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/__init__.py
@@ -1,0 +1,1 @@
+# user auth


### PR DESCRIPTION
> Why was this change necessary?

removing utf-8 at the top of the file caused `W391 blank line at end of file in user app` PEP8 errors

> How does it address the problem?

It adds a comment stating the purpose of the folder.

> Are there any side effects?

No.
