### PR TITLE
Add timezone information to datetime displayed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [2.x]
+- Add timezone information to datetime displayed in admin. (@saurabh)
 - Support for Django 2.0.x
+
 
 ## [1.11]
 

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -165,6 +165,12 @@ LANGUAGES = (
     ('en', _('English')),
 )
 
+if USE_TZ:
+    # Add timezone information to datetime displayed.
+    # https://mounirmesselmeni.github.io/2014/11/06/date-format-in-django-admin/
+    from django.conf.locale.en import formats as en_formats
+    en_formats.DATETIME_FORMAT = 'N j, Y, P (e)'
+
 # A tuple of directories where Django looks for translation files.
 LOCALE_PATHS = (
     str(APPS_DIR.path('locale')),


### PR DESCRIPTION
More info at https://mounirmesselmeni.github.io/2014/11/06/date-format-in-django-admin/

> Why was this change necessary?

It's not always clear in admin, the datetime display belongs to which timezone. 

> How does it address the problem?

Add the timezone details in the time displayed, in list view and elsewhere.

> Are there any side effects?

No
