### PR TITLE
Make whitenoise optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [2.x]
 - Add timezone information to datetime displayed in admin. (@saurabh)
 - Support for Django 2.0.x
-
+- Make whitenoise optional, add static and media routes to nginx if whitenoise is not enabled. (@tucosaurus)
 
 ## [1.11]
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,6 +9,7 @@
     , "version": "0.0.0"
     , "newrelic" : "y"
     , "postgis": "n"
+    , "add_whitenoise": "n"
     , "add_ansible": "y"
     , "letsencrypt": "y"
     , "letsencrypt_email": "backend+{{ cookiecutter.main_module|replace('_', '-') }}@fueled.com"

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,7 +9,7 @@
     , "version": "0.0.0"
     , "newrelic" : "y"
     , "postgis": "n"
-    , "add_whitenoise": "n"
+    , "enable_whitenoise": "n"
     , "add_ansible": "y"
     , "letsencrypt": "y"
     , "letsencrypt_email": "backend+{{ cookiecutter.main_module|replace('_', '-') }}@fueled.com"

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/nginx.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/nginx.conf.j2
@@ -68,12 +68,21 @@ http {
     gzip on;
     gzip_disable "msie6";
 
+    {%- if cookiecutter.add_whitenoise.lower() == 'y' %}
     # gzip_vary on;
     # gzip_proxied any;
     # gzip_comp_level 6;
     # gzip_buffers 16 8k;
     # gzip_http_version 1.1;
     # gzip_types text/plain text/css application/json text/javascript application/javascript application/x-javascript text/xml application/xml application/xml+rss;
+    {%- else %}
+    gzip_vary on;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_buffers 16 8k;
+    gzip_http_version 1.1;
+    gzip_types text/plain text/css application/json text/javascript application/javascript application/x-javascript text/xml application/xml application/xml+rss;
+    {%- endif %}
 
 
     # nginx-naxsi config

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/nginx.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/nginx.conf.j2
@@ -68,21 +68,21 @@ http {
     gzip on;
     gzip_disable "msie6";
 
-    {%- if cookiecutter.add_whitenoise.lower() == 'y' %}
+    {% if enable_whitenoise %}
     # gzip_vary on;
     # gzip_proxied any;
     # gzip_comp_level 6;
     # gzip_buffers 16 8k;
     # gzip_http_version 1.1;
     # gzip_types text/plain text/css application/json text/javascript application/javascript application/x-javascript text/xml application/xml application/xml+rss;
-    {%- else %}
+    {% else %}
     gzip_vary on;
     gzip_proxied any;
     gzip_comp_level 6;
     gzip_buffers 16 8k;
     gzip_http_version 1.1;
     gzip_types text/plain text/css application/json text/javascript application/javascript application/x-javascript text/xml application/xml application/xml+rss;
-    {%- endif %}
+    {% endif %}
 
 
     # nginx-naxsi config

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/nginx.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/nginx.conf.j2
@@ -67,23 +67,23 @@ http {
 
     gzip on;
     gzip_disable "msie6";
-
-    {% if enable_whitenoise %}
+{% endraw %}
+    {%- if cookiecutter.enable_whitenoise.lower() == 'y' %}
     # gzip_vary on;
     # gzip_proxied any;
     # gzip_comp_level 6;
     # gzip_buffers 16 8k;
     # gzip_http_version 1.1;
     # gzip_types text/plain text/css application/json text/javascript application/javascript application/x-javascript text/xml application/xml application/xml+rss;
-    {% else %}
+    {%- else %}
     gzip_vary on;
     gzip_proxied any;
     gzip_comp_level 6;
     gzip_buffers 16 8k;
     gzip_http_version 1.1;
     gzip_types text/plain text/css application/json text/javascript application/javascript application/x-javascript text/xml application/xml application/xml+rss;
-    {% endif %}
-
+    {%- endif %}
+{% raw %}
 
     # nginx-naxsi config
     # --------------------------------------

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
@@ -54,15 +54,14 @@ server {
         # set correct scheme
         uwsgi_param UWSGI_SCHEME $http_x_forwarded_proto;
     }
-
-    {% if enable_whitenoise %}
-    location /static/ {
+{% endraw %}
+    {%- if cookiecutter.enable_whitenoise.lower() == 'n' %}
+    {%raw%}location /static/ {
         alias {{ project_path }}/.staticfiles/;
     }
 
     location /media/ {
         alias {{ project_path }}/.media/;
-    }
-    {% endif %}
-
-}{%endraw%}
+    }{% endraw %}
+    {%- endif %}
+}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
@@ -55,7 +55,7 @@ server {
         uwsgi_param UWSGI_SCHEME $http_x_forwarded_proto;
     }
 
-    {%- if cookiecutter.add_whitenoise.lower() == 'n' %}
+    {% if enable_whitenoise %}
     location /static/ {
         alias {{ project_path }}/.staticfiles/;
     }

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
@@ -55,4 +55,14 @@ server {
         uwsgi_param UWSGI_SCHEME $http_x_forwarded_proto;
     }
 
+    {%- if cookiecutter.add_whitenoise.lower() == 'n' %}
+    location /static/ {
+        alias {{ project_path }}/.staticfiles/;
+    }
+
+    location /media/ {
+        alias {{ project_path }}/.media/;
+    }
+    {% endif %}
+
 }{%endraw%}

--- a/{{cookiecutter.github_repository}}/provisioner/vars.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/vars.yml
@@ -5,3 +5,4 @@ project_repo_remote: origin
 repo_version: master
 pg_gis: {{ 'True' if cookiecutter.postgis.lower() == 'y' else 'False' }}
 sass_with_django_compressor: {{ 'True' if cookiecutter.add_sass_with_django_compressor.lower() == 'y' else 'False' }}
+enable_whitenoise: {{ 'True' if cookiecutter.enable_whitenoise.lower() == 'y' else 'False'}}

--- a/{{cookiecutter.github_repository}}/provisioner/vars.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/vars.yml
@@ -5,4 +5,3 @@ project_repo_remote: origin
 repo_version: master
 pg_gis: {{ 'True' if cookiecutter.postgis.lower() == 'y' else 'False' }}
 sass_with_django_compressor: {{ 'True' if cookiecutter.add_sass_with_django_compressor.lower() == 'y' else 'False' }}
-enable_whitenoise: {{ 'True' if cookiecutter.enable_whitenoise.lower() == 'y' else 'False'}}

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -16,9 +16,11 @@ python-dotenv==0.7.1
 django-cors-headers==2.1.0
 {%- endif %}
 
+{%- if cookiecutter.add_whitenoise.lower() == 'y' %}
 # Staticfiles
 # -------------------------------------
 whitenoise==3.3.1
+{%- endif %}
 
 # Extensions
 # -------------------------------------

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -16,7 +16,7 @@ python-dotenv==0.7.1
 django-cors-headers==2.1.0
 {%- endif %}
 
-{%- if cookiecutter.add_whitenoise.lower() == 'y' %}
+{%- if cookiecutter.enable_whitenoise.lower() == 'y' %}
 # Staticfiles
 # -------------------------------------
 whitenoise==3.3.1

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -16,7 +16,7 @@ python-dotenv==0.7.1
 django-cors-headers==2.1.0
 {%- endif %}
 
-{%- if cookiecutter.enable_whitenoise.lower() == 'y' %}
+{% if cookiecutter.enable_whitenoise.lower() == 'y' -%}
 # Staticfiles
 # -------------------------------------
 whitenoise==3.3.1

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -131,7 +131,7 @@ MIDDLEWARE = [
 {%- endif %}
     'log_request_id.middleware.RequestIDMiddleware',  # For generating/adding Request id for all the logs
     'django.middleware.security.SecurityMiddleware',
-{%- if cookiecutter.add_whitenoise.lower() == 'y' %}
+{%- if cookiecutter.enable_whitenoise.lower() == 'y' %}
     'whitenoise.middleware.WhiteNoiseMiddleware',
 {%- endif %}
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -131,7 +131,9 @@ MIDDLEWARE = [
 {%- endif %}
     'log_request_id.middleware.RequestIDMiddleware',  # For generating/adding Request id for all the logs
     'django.middleware.security.SecurityMiddleware',
+{%- if cookiecutter.add_whitenoise.lower() == 'y' %}
     'whitenoise.middleware.WhiteNoiseMiddleware',
+{%- endif %}
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/{{cookiecutter.github_repository}}/settings/development.py
+++ b/{{cookiecutter.github_repository}}/settings/development.py
@@ -26,7 +26,7 @@ ALLOWED_HOSTS = ['*']
 # ------------------------------------------------------------------------------
 # Disable Django's static file handling and allow WhiteNoise to take over. This
 # helps in minimizing dev/prod differences when serving static files.
-INSTALLED_APPS = ('whitenoise.runserver_nostatic', )  INSTALLED_APPS
+INSTALLED_APPS = ('whitenoise.runserver_nostatic', ) + INSTALLED_APPS
 {%- endif %}
 
 

--- a/{{cookiecutter.github_repository}}/settings/development.py
+++ b/{{cookiecutter.github_repository}}/settings/development.py
@@ -21,11 +21,14 @@ INTERNAL_IPS = ('127.0.0.1', '192.168.33.12', )
 
 ALLOWED_HOSTS = ['*']
 
+{%- if cookiecutter.add_whitenoise.lower() == 'y' %}
 # Staticfiles
 # ------------------------------------------------------------------------------
 # Disable Django's static file handling and allow WhiteNoise to take over. This
 # helps in minimizing dev/prod differences when serving static files.
-INSTALLED_APPS = ('whitenoise.runserver_nostatic', ) + INSTALLED_APPS
+INSTALLED_APPS = ('whitenoise.runserver_nostatic', )  INSTALLED_APPS
+{%- endif %}
+
 
 # SECRET CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/{{cookiecutter.github_repository}}/settings/development.py
+++ b/{{cookiecutter.github_repository}}/settings/development.py
@@ -21,7 +21,7 @@ INTERNAL_IPS = ('127.0.0.1', '192.168.33.12', )
 
 ALLOWED_HOSTS = ['*']
 
-{%- if cookiecutter.add_whitenoise.lower() == 'y' %}
+{%- if cookiecutter.enable_whitenoise.lower() == 'y' %}
 # Staticfiles
 # ------------------------------------------------------------------------------
 # Disable Django's static file handling and allow WhiteNoise to take over. This

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -3,7 +3,9 @@
 Adds sensible default for running app in production.
 - Disable DEBUG
 - Make SECRET_KEY mandatory
+{%- if cookiecutter.add_whitenoise.lower() == 'y' %}
 - Use whitenoise to serve static files
+{%- endif %}
 - Disable browsable API
 """
 
@@ -116,7 +118,12 @@ if ENABLE_MEDIA_UPLOAD_TO_S3:
 
 # Static Assests
 # ------------------------
+{%- if cookiecutter.add_whitenoise.lower() == 'y' %}
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+{%- else %}
+STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'
+{%- endif %}
+
 {%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' %}
 
 # Compress static files offline

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -3,7 +3,7 @@
 Adds sensible default for running app in production.
 - Disable DEBUG
 - Make SECRET_KEY mandatory
-{%- if cookiecutter.add_whitenoise.lower() == 'y' %}
+{%- if cookiecutter.enable_whitenoise.lower() == 'y' %}
 - Use whitenoise to serve static files
 {%- endif %}
 - Disable browsable API
@@ -118,7 +118,7 @@ if ENABLE_MEDIA_UPLOAD_TO_S3:
 
 # Static Assests
 # ------------------------
-{%- if cookiecutter.add_whitenoise.lower() == 'y' %}
+{%- if cookiecutter.enable_whitenoise.lower() == 'y' %}
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 {%- else %}
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'

--- a/{{cookiecutter.github_repository}}/wsgi.py
+++ b/{{cookiecutter.github_repository}}/wsgi.py
@@ -18,7 +18,7 @@ import os
 # Third Party Stuff
 from django.core.wsgi import get_wsgi_application
 from dotenv import load_dotenv
-{%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' %}
+{%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' and cookiecutter.add_whitenoise.lower() == 'y' %}
 from whitenoise.django import DjangoWhiteNoise
 
 
@@ -58,7 +58,7 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings.production')
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
-{%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' %}
+{%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' and cookiecutter.add_whitenoise.lower() == 'y' %}
 application = DjangoCompressorWhiteNoise(get_wsgi_application())
 {%- else %}
 application = get_wsgi_application()

--- a/{{cookiecutter.github_repository}}/wsgi.py
+++ b/{{cookiecutter.github_repository}}/wsgi.py
@@ -18,7 +18,7 @@ import os
 # Third Party Stuff
 from django.core.wsgi import get_wsgi_application
 from dotenv import load_dotenv
-{%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' and cookiecutter.add_whitenoise.lower() == 'y' %}
+{%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' and cookiecutter.enable_whitenoise.lower() == 'y' %}
 from whitenoise.django import DjangoWhiteNoise
 
 
@@ -58,7 +58,7 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings.production')
 # This application object is used by any WSGI server configured to use this
 # file. This includes Django's development server, if the WSGI_APPLICATION
 # setting points here.
-{%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' and cookiecutter.add_whitenoise.lower() == 'y' %}
+{%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' and cookiecutter.enable_whitenoise.lower() == 'y' %}
 application = DjangoCompressorWhiteNoise(get_wsgi_application())
 {%- else %}
 application = get_wsgi_application()


### PR DESCRIPTION
> Why was this change necessary?

https://github.com/Fueled/django-init/issues/277

> How does it address the problem?

- Adds `enable_whitenoise` option to cookiecutter which defaults to `no`. 
- Falls back to manifest static storage.
- Enables gzip compression on nginx if whitenoise is not enabled.
- Adds static and media routes.

> Are there any side effects?

Yes. As listed above.
