### PR TITLE
Make Redis Installation Compulsory

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/site.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/site.yml
@@ -11,11 +11,10 @@
     - nginx
     - postgresql
     - project_data
-{%- if cookiecutter.add_celery.lower() == 'y' %}
     - redis
+{%- if cookiecutter.add_celery.lower() == 'y' %}
     - celery
 {%- else %}
-    # - redis
     # - celery
 {%- endif %}
 
@@ -33,11 +32,10 @@
     - nginx
     - postgresql
     - project_data
-{%- if cookiecutter.add_celery.lower() == 'y' %}
     - redis
+{%- if cookiecutter.add_celery.lower() == 'y' %}
     - celery
 {%- else %}
-    # - redis
     # - celery
 {%- endif %}
 
@@ -55,11 +53,10 @@
     - nginx
     - project_data
     - postgresql
-{%- if cookiecutter.add_celery.lower() == 'y' %}
     - redis
+{%- if cookiecutter.add_celery.lower() == 'y' %}
     - celery
 {%- else %}
-    # - redis
     # - celery
 {%- endif %}
 
@@ -76,10 +73,9 @@
     - common
     - nginx
     - project_data
-{%- if cookiecutter.add_celery.lower() == 'y' %}
     - redis
+{%- if cookiecutter.add_celery.lower() == 'y' %}
     - celery
 {%- else %}
-    # - redis
     # - celery
 {%- endif %}


### PR DESCRIPTION
If you Redis is not installed the website will show 504 gateway timeout sometimes

> Why was this change necessary?

Make Redis installation compulsory

> How does it address the problem?

It helps in the removing 504 gateway timeout error which occurs sometimes after deployment

> Are there any side effects?

No, Just install Redis everytime
