### PR TITLE
Optional heroku support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 - Add timezone information to datetime displayed in admin. (@saurabh)
 - Support for Django 2.0.x
 - Make whitenoise optional, add static and media routes to nginx if whitenoise is not enabled. (@tucosaurus)
+- Make heroku deployment optional. (@tucosaurus)
 
 ## [1.11]
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Project template for django based projects, optimized for making REST API with d
 - Python 3.5+
 - [12-Factor][12factor] based settings management via [django-environ], reads settings from `.env` if present.
 - PostresSQL everywhere (support of postgis is available)
-- Ready to deploy on Heroku and Ubuntu 16 LTS via [Ansible](Optional)
+- Ready to deploy on Heroku (optional) and Ubuntu 16 LTS via [Ansible](Optional)
 - [Django Rest Framework][drf] 3.7.x. ready.
 - Uses `django_sites` instead of `django.contrib.sites`
 - Use [mkdocs] for project documentation.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -9,6 +9,7 @@
     , "version": "0.0.0"
     , "newrelic" : "y"
     , "postgis": "n"
+    , "enable_heroku_deployment": "n"
     , "add_ansible": "y"
     , "letsencrypt": "y"
     , "letsencrypt_email": "backend+{{ cookiecutter.main_module|replace('_', '-') }}@fueled.com"

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -25,6 +25,10 @@ else
     read  yn
 fi
 
+if echo "{{ cookiecutter.enable_heroku_deployment }}" | grep -iq "^n"; then
+    rm -rf Procfile runtime.txt bin
+fi
+
 if echo "{{ cookiecutter.add_ansible }}" | grep -iq "^n"; then
     rm -rf provisioner Vagrantfile
 fi

--- a/{{cookiecutter.github_repository}}/.travis.yml
+++ b/{{cookiecutter.github_repository}}/.travis.yml
@@ -40,6 +40,7 @@ notifications:
     on_success: change  # [always|never|change]
     on_failure: always  # [always|never|change]
 
+{%- if cookiecutter.enable_heroku_deployment.lower() == 'y' %}
 deploy:
   provider: heroku
   buildpack: python
@@ -53,3 +54,4 @@ deploy:
     prod: {{ cookiecutter.main_module }}-prod
   on:
     repo: {{ cookiecutter.github_username }}/{{ cookiecutter.github_repository }}
+{% endif %}

--- a/{{cookiecutter.github_repository}}/circle.yml
+++ b/{{cookiecutter.github_repository}}/circle.yml
@@ -34,6 +34,7 @@ test:
     {% if cookiecutter.add_ansible.lower() == 'y' %}- ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check{% endif %}
 
 ## Customize deployment commands
+{% if cookiecutter.enable_heroku_deployment.lower() == 'y' %}
 # To enable Heroku deployment add heroku API key under project settings deployment in circle
 deployment:
   dev:
@@ -51,6 +52,7 @@ deployment:
     owner: {{ cookiecutter.github_username }}
     heroku:
       appname: {{ cookiecutter.main_module }}-prod
+{% endif %}
 
 ## Custom notifications
 #notify:

--- a/{{cookiecutter.github_repository}}/docs/backend/server_config.md
+++ b/{{cookiecutter.github_repository}}/docs/backend/server_config.md
@@ -4,6 +4,7 @@
 
 Following third-party services are required in order to setup/deploy this project successfully.
 
+{%- if cookiecutter.enable_heroku_deployment.lower() == 'y' %}
 ## Heroku
 
 Heroku is platform as a service provider. We use to host the primarily web server along with different services required by this project like postgres database, newrelic, redis. See getting started docs [here][heroku-docs], you'll require to create an account and install the [cli-tool][heroku-cli] to successfully deploy this project.
@@ -12,6 +13,7 @@ Heroku is platform as a service provider. We use to host the primarily web serve
 [heroku-cli]: https://devcenter.heroku.com/articles/heroku-command
 
 Note: Alternatively, you should be able configure a linux instance to run the same project as well, heroku like settings can be added via `.env` file. (refer: `settings/common.py`). Just that, this documentation and project is focused more with Heroku as platform of choice.
+{%- endif %}
 
 ## Amazon S3
 
@@ -24,13 +26,16 @@ After [signing up][s3-signup] for Amazon S3, [setup][s3-iam-setup] an IAM user w
 [s3-iam-setup]: https://rbgeek.wordpress.com/2014/07/18/amazon-iam-user-creation-for-single-s3-bucket-access/
 
 Note: 
+{% if cookiecutter.enable_heroku_deployment.lower() == 'y' %}
 - Heroku doesn't provide a persistent storage for uploaded content, best practise is to store the uploaded files in S3 buckets.
+{% endif %}
 - IAM user must have permission to list, update, create objects in S3.
 
 # Deploying Project
 
 The deployment are managed via travis, but for the first time you'll need to set the configuration values on each of the server. Read this only, if you need to deploy for the first time.
 
+{%- if cookiecutter.enable_heroku_deployment.lower() == 'y' %}
 ### Heroku
 
 Run these commands to deploy this project on Heroku (substitue all references of `<heroku-app-name>` with the name your heroku application.)
@@ -92,6 +97,7 @@ DJANGO_AWS_STORAGE_BUCKET_NAME=<YOUR_BUCKET_NAME_HERE>
 **Note:**
 - Use `--app=<heroku-app-name>` if you have more than one Heroku app configured in current project.
 - Update `travis.yml`, and add the `<heroku-app-name>` to automatically deploy to this configured Heroku app.
+{% endif %}
 
 {%- if cookiecutter.add_ansible.lower() == 'y' %}
 

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -60,8 +60,10 @@ MIDDLEWARE = ['django_auth_wall.middleware.BasicAuthMiddleware', ] + MIDDLEWARE
 # that header/value, request.is_secure() will return True.
 # WARNING! Only set this if you fully understand what you're doing. Otherwise,
 # you may be opening yourself up to a security risk.
+{%- if cookiecutter.enable_heroku_deployment.lower() == 'y' %}
 # This ensures that Django will be able to detect a secure connection
 # properly on Heroku.
+{%- endif %}
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 #  SECURITY
@@ -156,7 +158,9 @@ CACHES = {
             'PARSER_CLASS': 'redis.connection.HiredisParser',
             'CONNECTION_POOL_CLASS': 'redis.BlockingConnectionPool',
             'CONNECTION_POOL_CLASS_KWARGS': {
+{%- if cookiecutter.enable_heroku_deployment.lower() == 'y' %}
                 # Hobby redistogo on heroku only supports max. 10, increase as required.
+{%- endif %}
                 'max_connections': env.int('REDIS_MAX_CONNECTIONS', default=10),
                 'timeout': 20,
             }


### PR DESCRIPTION
> Why was this change necessary?

fueled does not use heroku for deploying its apps anymore. 

> How does it address the problem?

heroku deployment made optional to keep everyone happy

> Are there any side effects?

Adds enable_heroku_deployment option to the cookiecutter
