### PR TITLE
fix(tests): Use pytest instead of py.test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [2.x]
+- Use new `pytest` instead of `py.test`. (@CuriousLearner)
 - Upgrade all the systems to use python 3.6.
 - Add timezone information to datetime displayed in admin. (@saurabh)
 - Support for Django 2.0.x

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Project template for django based projects, optimized for making REST API with d
 - [Django Rest Framework][drf] 3.7.x. ready.
 - Uses `django_sites` instead of `django.contrib.sites`
 - Use [mkdocs] for project documentation.
-- Uses [py.test] as test runner.
+- Uses [pytest] as test runner.
 - `travis.yml` for running isolated tests and deployments to dev/qa/prod environment on Heroku from git branches.
 - Custom `User` app, for easier extensibility.
 - Media storage using Amazon S3 (optional)
@@ -67,7 +67,7 @@ Built with ♥ at [Fueled](https://fueled.com)
 [wiki]: https://github.com/Fueled/django-init/wiki
 [mkdocs]: http://www.mkdocs.org/
 [12factor]: http://12factor.net
-[py.test]: http://pytest.org/
+[pytest]: http://pytest.org/
 [django-environ]: https://github.com/joke2k/django-environ
 [Ansible]: http://docs.ansible.com/index.html
 [devrecargar]: https://github.com/scottwoodall/django-devrecargar

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -74,7 +74,7 @@ if echo "$yn" | grep -iq "^y"; then
         echo ""
         echo "cd {{ cookiecutter.github_repository }}"
         echo "./venv/bin/activate"
-        echo "py.test"
+        echo "pytest"
         echo "./manage.py runserver"
         echo ""
         echo "============================================"

--- a/{{cookiecutter.github_repository}}/.travis.yml
+++ b/{{cookiecutter.github_repository}}/.travis.yml
@@ -32,7 +32,7 @@ before_script:
 
 script:
 - flake8
-- py.test --cov -v --tb=native
+- pytest --cov -v --tb=native
 {% if cookiecutter.add_ansible.lower() == 'y' %}- ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check{% endif %}
 
 notifications:

--- a/{{cookiecutter.github_repository}}/circle.yml
+++ b/{{cookiecutter.github_repository}}/circle.yml
@@ -29,7 +29,7 @@ database:
 test:
   override:
     - flake8
-    - py.test --cov --cov-report term-missing -v --tb=native --junitxml=$CIRCLE_TEST_REPORTS/summary.xml
+    - pytest --cov --cov-report term-missing -v --tb=native --junitxml=$CIRCLE_TEST_REPORTS/summary.xml
     - coverage html -d $CIRCLE_ARTIFACTS
     {% if cookiecutter.add_ansible.lower() == 'y' %}- ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check{% endif %}
 

--- a/{{cookiecutter.github_repository}}/fabfile.py
+++ b/{{cookiecutter.github_repository}}/fabfile.py
@@ -66,7 +66,7 @@ def test(options='--pdb --cov'):
     """
     with virtualenv():
         local('flake8 .')
-        local('py.test %s' % options)
+        local('pytest %s' % options)
 
 
 def serve(host='127.0.0.1:8000'):

--- a/{{cookiecutter.github_repository}}/settings/__init__.py
+++ b/{{cookiecutter.github_repository}}/settings/__init__.py
@@ -3,5 +3,5 @@ import sys
 
 if 'test' in sys.argv:
     print('\033[1;91mNo django tests.\033[0m')
-    print('Try: \033[1;33mpy.test\033[0m')
+    print('Try: \033[1;33mpytest\033[0m')
     sys.exit(0)

--- a/{{cookiecutter.github_repository}}/settings/testing.py
+++ b/{{cookiecutter.github_repository}}/settings/testing.py
@@ -1,4 +1,4 @@
-# Do this here, so that .env get loaded while running `py.test` from shell
+# Do this here, so that .env get loaded while running `pytest` from shell
 from dotenv import load_dotenv, find_dotenv
 load_dotenv(find_dotenv())
 


### PR DESCRIPTION
> Why was this change necessary?

The new `pytest` is preferred over old `py.test` https://stackoverflow.com/a/41893170/3535547

> How does it address the problem?

The `py.test` can potentially be deprecated in future, so it is best to use `pytest`

> Are there any side effects?

None.

