### PR TITLE
feat(provisioner) - remove extra uwsgi build from common tasks

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/common/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/common/tasks/main.yml
@@ -60,11 +60,3 @@
 
 - name: ensure there is a user www-data
   user: name=www-data group=www-data system=yes
-
-# https://dev.to/pauloxnet/how-to-use-uwsgi-with-ptyhon36-in-ubuntu
-- name: compile python36 plugin for uwsgi
-  shell: >
-    mkdir -p /usr/src/uwsgi/plugins/python &&
-    PYTHON=python3.6 uwsgi --build-plugin "/usr/src/uwsgi/plugins/python python36" &&
-    mv python36_plugin.so /usr/lib/uwsgi/plugins/python36_plugin.so &&
-    chmod 644 /usr/lib/uwsgi/plugins/python36_plugin.so


### PR DESCRIPTION
> Why was this change necessary?

We are trying to build the uwsgi plugin before installing it.  

> How does it address the problem?

Removes the unnecessary task. We install the plugin in the uwsgi setup task file also.

> Are there any side effects?

No.
