### PR TITLE
fix(base/models): Fix naming in TimeStampedUUIDModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.x]
 
+- Change `created` and `modified` to `created_at` & `modified_at` respectively in `TimeStampedUUIDModel`. ([@CuriousLearner])
 - Add `SWAGGER_SETTINGS` as per current drf setup ([@theskumar])
 - Fix celerybeat service to be started/stopped correctly from systemctl. ([@CuriousLearner])
 - Use new `pytest` instead of `py.test`. ([@CuriousLearner])

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/models.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/models.py
@@ -21,8 +21,8 @@ class TimeStampedUUIDModel(UUIDModel):
     """An abstract base class model that provides self-updating
     ``created`` and ``modified`` fields with UUID as primary_key field.
     """
-    created = models.DateTimeField(auto_now_add=True, editable=False)
-    modified = models.DateTimeField(auto_now=True, editable=False)
+    created_at = models.DateTimeField(auto_now_add=True, editable=False)
+    modified_at = models.DateTimeField(auto_now=True, editable=False)
 
     class Meta:
         abstract = True


### PR DESCRIPTION
> Why was this change necessary?

Fixes naming for `created` and `modified` to `created_at` & `modified_at` respectively in `TimeStampedUUIDModel`

> How does it address the problem?

`created` & `modified` aren't explicitly enough that they actually store `DateTimeField`.

> Are there any side effects?

None.