### PR TITLE
Add flake8 in travis builds of django-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.x]
 
+- Add flake8 in travis builds for django-init. ([@CuriousLearner])
 - Change `created` and `modified` to `created_at` & `modified_at` respectively in `TimeStampedUUIDModel`. ([@CuriousLearner])
 - Add `SWAGGER_SETTINGS` as per current drf setup ([@theskumar])
 - Fix celerybeat service to be started/stopped correctly from systemctl. ([@CuriousLearner])

--- a/run_test.sh
+++ b/run_test.sh
@@ -18,6 +18,7 @@ yes 'y' | cookiecutter . --no-input
 cd hello-world-web;
 ansible-playbook -i provisioner/hosts provisioner/site.yml --syntax-check
 source venv/bin/activate
+flake8
 fab test:"--cov"
 # Running 2to3 to ensure python3 compatible code is written
 2to3 hello_world

--- a/run_test.sh
+++ b/run_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Setup for returning a non-zero exit code if any of the command fails.
+err=0
+trap 'err=1' ERR
+
 # Setup
 createdb hello_world
 if [ $? -ne 0 ]; then
@@ -22,3 +26,5 @@ flake8
 fab test:"--cov"
 # Running 2to3 to ensure python3 compatible code is written
 2to3 hello_world
+
+test $err = 0 # Return non-zero if any command failed

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/api.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/api.py
@@ -9,7 +9,7 @@ from {{cookiecutter.main_module}}.base.api.mixins import MultipleSerializerMixin
 from {{cookiecutter.main_module}}.users import services as user_services
 
 
-from . import serializers, backends, services, tokens
+from . import serializers, services, tokens
 
 
 class AuthViewSet(MultipleSerializerMixin, viewsets.GenericViewSet):

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/api.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/api.py
@@ -9,7 +9,7 @@ from {{cookiecutter.main_module}}.base.api.mixins import MultipleSerializerMixin
 from {{cookiecutter.main_module}}.users import services as user_services
 
 
-from . import serializers, services, tokens
+from . import serializers, backends, services, tokens
 
 
 class AuthViewSet(MultipleSerializerMixin, viewsets.GenericViewSet):


### PR DESCRIPTION
> Why was this change necessary?

Currently there can be errors due to flake8, as in the builds we're not testing if the code follows standards.

> How does it address the problem?

Added flake8 command in `run_test.sh`. Also, `run_test.sh` has been modified to give a non-zero exit status if any of the commands fail.

> Are there any side effects?

None
