### PR TITLE
chore(provisioner/roles/nginx): remove ` State 'installed' is deprecated.` warning

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/tasks/main.yml
@@ -5,7 +5,7 @@
     update_cache: yes
 
 - name: install NGINX Server.
-  apt: pkg=nginx-full state=installed
+  apt: pkg=nginx-full state=present
 
 - name: make sure ssl directory exists
   file: path={{ ssl_cert_dir }} state=directory


### PR DESCRIPTION


> Why was this change necessary?

- Since state=installed will be removed in version 2.9 of ansible hence it make sense to do the change

> How does it address the problem?

- by changing the variable state=present. The warning nullifies
> Are there any side effects?

No. Tried with my own setup. :) 
