### PR TITLE
Add LocaleMiddleware in settings to add multi-language support

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -179,6 +179,7 @@ MIDDLEWARE = [
     'whitenoise.middleware.WhiteNoiseMiddleware',
 {%- endif %}
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
> Why was this change necessary?

Other parameters for supporting translation and internationalization are already there in the settings. But for multilingual support, LocaleMiddleware is needed to convert the response in the requested language.

> How does it address the problem?

LocaleMiddleware is needed to convert the response in the requested language.

> Are there any side effects?

None.
