### PR TITLE
migrated COMPRESS_CSS_FILTERS to COMPRESS_FILTERS as per the document…

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -335,10 +335,12 @@ STATICFILES_FINDERS = (
 {%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' %}
 
 # Django Compressor Configuration
-COMPRESS_CSS_FILTERS = [
-    'django_compressor_autoprefixer.AutoprefixerFilter',
-    'compressor.filters.cssmin.CSSMinFilter',
-]
+COMPRESS_FILTERS = {
+    'css': [
+        'django_compressor_autoprefixer.AutoprefixerFilter',
+        'compressor.filters.cssmin.CSSMinFilter'
+    ]
+}
 
 COMPRESS_PRECOMPILERS = (
     ('text/x-scss', 'django_libsass.SassCompiler'),

--- a/{{cookiecutter.github_repository}}/settings/testing.py
+++ b/{{cookiecutter.github_repository}}/settings/testing.py
@@ -16,5 +16,5 @@ INSTALLED_APPS += ('tests', )  # noqa: F405
 # Travis CI run with node 0.10.0 which is incompatible with the version
 # postcss required.
 # This causes the autoprefixer to not run on the complied css.
-COMPRESS_CSS_FILTERS.remove('django_compressor_autoprefixer.AutoprefixerFilter')  # noqa: F405
+COMPRESS_FILTERS = {}
 {%- endif %}


### PR DESCRIPTION
…ation - https://django-compressor.readthedocs.io/en/latest/settings/#django.conf.settings.COMPRESS_CSS_FILTERS

> Why was this change necessary?

According to the docs of Django Compressor COMPRESS_CSS_FILTER (& COMPRESS_JS_FILTER) is now an old parameter which has been succeed by COMPRESS_FILTER.

> How does it address the problem?

I changed COMPRESS_CSS_FILTER to COMPRESS_FILTER in the project.

> Are there any side effects?

None.
