### PR TITLE
feat(localization): Add compilemessages & fix default pypi mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [2.x]
 
+- Add task for compiling static string translations. ([@CuriousLearner])
+- Ensure pypi and easy_install mirror is set to `pypi.python.org` ([@CuriousLearner])
 - Move `paginated_response` utility to `base.api.pagination`. ([@theskumar])
 - Add flake8 in travis builds for django-init. ([@CuriousLearner])
 - Change `created` and `modified` to `created_at` & `modified_at` respectively in `TimeStampedUUIDModel`. ([@CuriousLearner])

--- a/{{cookiecutter.github_repository}}/provisioner/roles/common/files/pip.conf
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/common/files/pip.conf
@@ -1,0 +1,5 @@
+[global]
+index-url=https://pypi.python.org/simple/
+
+[install]
+trusted-host=pypi.python.org

--- a/{{cookiecutter.github_repository}}/provisioner/roles/common/files/pydistutils.cfg
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/common/files/pydistutils.cfg
@@ -1,0 +1,2 @@
+[easy_install]
+index-url=https://pypi.python.org/simple/

--- a/{{cookiecutter.github_repository}}/provisioner/roles/common/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/common/tasks/main.yml
@@ -51,6 +51,20 @@
     - { src: 'bashrc', dest: '.bashrc' }
     - { src: 'inputrc', dest: '.inputrc' }
 
+- name: ensure .pip directory exists
+  file:
+    path: /home/{{ user }}/.pip
+    state: directory
+    owner: "{{ user }}"
+    group: "{{ user }}"
+    mode: 0775
+
+- name: ensure default pypi mirror for easy_install and virtualenv is pypi.python.org
+  copy: src={{ item.src }} dest=/home/{{ user }}/{{ item.dest }} owner={{ user }} group={{ user }}
+  with_items:
+    - { src: 'pydistutils.cfg', dest: '.pydistutils.cfg' }
+    - { src: 'pip.conf', dest: '.pip/pip.conf' }
+
 - name: apt_get install common packages
   apt: pkg={{ item }} state=present
   with_items: "{{base_ubuntu.common.apt_packages}}"

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
@@ -57,6 +57,11 @@
 
 - import_tasks: uwsgi-setup.yml
 
+- name: run compilemessages for static translations
+  django_manage: command=compilemessages app_path={{ project_path }} virtualenv={{ venv_path }}
+  become: false
+  tags: ['deploy']
+
 - name: reload uwsgi processes
   command: uwsgi --reload {{ uwsgi_pid_file }}
   become: true


### PR DESCRIPTION
> Why was this change necessary?

Some cloud providers like Alibaba cloud uses default pypi and easy_install mirror set to aliyum on booting up the ECS instance.

However, the deployment will fail, since for `easy_install`,  from `.pydistutils.cfg`, the `virtualenv` is not properly made (without any `bin` folder, `activate` script etc.)

Also, the `.pip/pip.conf` ensures that the global url for pypi mirror for fetching packages from requirements is actual python.org server for reasons mentioned above.

Apart from these changes, I've added a `compilemessages` command, so that the static messages are translated on every deployment if available.

> How does it address the problem?

Reasons mentioned above.

> Are there any side effects?

None.
