### PR TITLE
fix(provisioner/nginx.conf): Minor typo fix

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/nginx.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/nginx.conf.j2
@@ -43,7 +43,7 @@ http {
     # when serving user-supplied content, include a X-Content-Type-Options: nosniff header along with the Content-Type: header,
     # to disable content-type sniffing on some browsers.
     # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-    # currently suppoorted in IE > 8 http://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx
+    # currently supported in IE > 8 http://blogs.msdn.com/b/ie/archive/2008/09/02/ie8-security-part-vi-beta-2-update.aspx
     # http://msdn.microsoft.com/en-us/library/ie/gg622941(v=vs.85).aspx
     # 'soon' on Firefox https://bugzilla.mozilla.org/show_bug.cgi?id=471020
     add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
> Why was this change necessary?

Just a minor typo fix in one of the comments in `nginx.conf`

> Are there any side effects?

None
