### PR TITLE
fix(system) - Update celery to avoid kombu incompatibility

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -61,7 +61,7 @@ raven==6.6.0
 
 # Async Tasks
 # -------------------------------------
-celery[redis]==4.1.0
+celery[redis]==4.1.1
 {%- endif %}
 
 # Auth Stuff


### PR DESCRIPTION


> Why was this change necessary?
Celery 4.1.0 is breaking because it includes an incompatible kombu version.


> How does it address the problem?
This PR upgrades celery to 4.1.1 to avoid it.

> Are there any side effects?
Yes. Celery version is upgraded.
add your text here...
