### PR TITLE
change `pages` option in `mkdocs.yml` file to `nav`

### DIFF
--- a/{{cookiecutter.github_repository}}/mkdocs.yml
+++ b/{{cookiecutter.github_repository}}/mkdocs.yml
@@ -4,7 +4,7 @@ site_description: {{ cookiecutter.project_description }}
 site_author: {{ cookiecutter.github_username }}
 repo_url: https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.github_repository }}
 
-pages:
+nav:
 - Home: 'index.md'
 - API:
   - 'Overview & Usages': 'api/overview.md'


### PR DESCRIPTION
> Why was this change necessary?

WARNING -  Config value: 'pages'. Warning: The 'pages' configuration option has been deprecated and will be removed in a future release of MkDocs. Use 'nav' instead.

Aborted with 1 Configuration Warnings in 'strict' mode!

> How does it address the problem?

Changing `pages` option to `nav` in `mkdocs.yml` clears the error.

> Are there any side effects?

No. 
