### PR TITLE
chore(provisioner/): add `gettext` package for common install option

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/common/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/common/defaults/main.yml
@@ -32,4 +32,5 @@ base_ubuntu:
       - libpq-dev
       - postgis
       - ca-certificates
+      - gettext
 {% endraw %}


### PR DESCRIPTION
> Why was this change necessary?

run compilemessages for static translations causes the following error  on new instance setup [tested on Ubuntu 16.04 Image] 

```
:stderr: CommandError: Can't find msgfmt. Make sure you have GNU gettext tools 0.15 or newer installed.
```

> How does it address the problem?

Installs the required package

> Are there any side effects?

Nope
