### PR TITLE
fix(base/api/routers): Deprecating DynamicListRoute

### DIFF
--- a/{{cookiecutter.github_repository}}/tests/integration/test_auth.py
+++ b/{{cookiecutter.github_repository}}/tests/integration/test_auth.py
@@ -104,7 +104,7 @@ def test_user_password_reset_and_confirm(client, settings, mocker):
     token = kwargs['context']['token']
 
     # confirm we can reset password using context values
-    new_password = 'paSswOrd2'
+    new_password = 'completelyNEWpass.123'
     password_reset_confirm_data = {
         'new_password': new_password,
         'token': token

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/api/routers.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/api/routers.py
@@ -27,11 +27,12 @@ class SingletonRouter(routers.SimpleRouter):
             initkwargs={'suffix': ''}
         ),
         # Dynamically generated list routes.
-        # Generated using @list_route decorator
+        # Generated using @action decorator
         # on methods of the viewset.
-        routers.DynamicListRoute(
-            url=r'^{prefix}/{methodname}{trailing_slash}$',
-            name='{basename}-{methodnamehyphen}',
+        routers.DynamicRoute(
+            url=r'^{prefix}/{url_path}$',
+            name='{basename}-{url_name}',
+            detail=False,
             initkwargs={}
         ),
     ]


### PR DESCRIPTION
> Why was this change necessary?

DynamicListRoute has been deprecated since DRFv3.8.0 ( #315 ).

> How does it address the problem?

DynamicListRoute has been replaced with DynamicRoute in `base/api/routers.py`

> Are there any side effects?

To use DynamicRoute one has to declare viewset action with `@action` decorator. So, all the extra viewset actions should be refactored to make it work.
