### PR TITLE
fix(settings/dev): Added MEDIA_URL configuration

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/development.py
+++ b/{{cookiecutter.github_repository}}/settings/development.py
@@ -87,3 +87,9 @@ DEBUG_TOOLBAR_CONFIG = {
 
 # This will expose all browsable api urls. For dev the default value is true
 API_DEBUG = env.bool('API_DEBUG', default=True)
+
+# MEDIA CONFIGURATION
+# ------------------------------------------------------------------------------
+
+# Media configuration to support deployment of media files while is debug=True or development.
+MEDIA_URL = env("MEDIA_URL", default="/media/")


### PR DESCRIPTION
Why was this change necessary?
django-init was unable to serve media files. This addresses #323.

How does it address the problem?
MEDIA_URL configuration is added to support serving media file.

Are there any side effects?
None.

