### PR TITLE
chore(requirements) - pin pytest version to avoid attrs incompatability

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -15,6 +15,7 @@ ipdb==0.11
 
 # Testing and coverage
 # -------------------------------------
+pytest==3.9.2
 pytest-django==3.4.3
 pytest-cov==2.6.0
 django-dynamic-fixture==2.0.0


### PR DESCRIPTION
> Why was this change necessary?
Travis builds are failing since one of the packages installed downgrades to pytest 3.3 which uses a deprecated api of attrs.

> How does it address the problem?
It pins the pytest version to the latest one.

> Are there any side effects?
None apart from pinning down pytest version.
