### PR TITLE
fix(provisioner) - install gettext for compilemessages

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
@@ -30,6 +30,11 @@
   become: false
   tags: ['configure']
 
+- name: install gettext for translations
+  apt:
+    pkg: gettext
+    state: present
+
 - name: collect static
   django_manage: command=collectstatic app_path={{ project_path }} virtualenv={{ venv_path }}
   become: false


### PR DESCRIPTION
> Why was this change necessary?

env deploys fail after compilemessages was added to project_data role

> How does it address the problem?

installs gettext required by compilemessages

> Are there any side effects?

Yes. Installs gettext if not present. This is an additional dependency.
