### PR TITLE
chore(requirements): Upgrade Django=2.1.4 & DRF 3.9.0

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -1,6 +1,6 @@
 # Core Stuff
 # -------------------------------------
-Django==2.1.2
+Django==2.1.4
 
 # Configuration
 # -------------------------------------
@@ -33,7 +33,7 @@ django-versatileimagefield==1.10
 
 # REST APIs
 # -------------------------------------
-djangorestframework==3.8.2
+djangorestframework==3.9.0
 django-rest-swagger==2.2.0
 {%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' %}
 

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/api_urls.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/api_urls.py
@@ -10,8 +10,8 @@ default_router = DefaultRouter(trailing_slash=False)
 singleton_router = SingletonRouter(trailing_slash=False)
 
 # Register all the django rest framework viewsets below.
-default_router.register('auth', AuthViewSet, base_name='auth')
-singleton_router.register('me', CurrentUserViewSet, base_name='me')
+default_router.register('auth', AuthViewSet, basename='auth')
+singleton_router.register('me', CurrentUserViewSet, basename='me')
 
 # Combine urls from both default and singleton routers and expose as
 # 'urlpatterns' which django can pick up from this module.


### PR DESCRIPTION
> Why was this change necessary?

To update the tool to support the latest version of Django and DRF.

> How does it address the problem?

Upgrade Django to `2.1.4` and DRF to `3.9.0` and prevent deprecation warning in `api_urls` by using `basename` in favor of `base_name`.

> Are there any side effects?

None
