### PR TITLE
chore(requirements): Downgrade Swagger to 2.1.2 from 2.2.0

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -34,7 +34,7 @@ django-versatileimagefield==1.10
 # REST APIs
 # -------------------------------------
 djangorestframework==3.9.0
-django-rest-swagger==2.2.0
+django-rest-swagger==2.1.2
 {%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' %}
 
 # Static files


### PR DESCRIPTION
Temporary fix for #330

> Why was this change necessary?

To avoid error on swagger index page saying `rest_framework_swagger/base.html` Template not found

> How does it address the problem?

Swagger works again for the newly spawned projects.

> Are there any side effects?

None
