### PR TITLE
fix(provisioner/roles/redis): Update ansible state from installed to present

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/redis/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/redis/tasks/main.yml
@@ -7,4 +7,4 @@
 - name: install redis server
   apt:
     pkg: redis-server
-    state: installed
+    state: present


### PR DESCRIPTION
> Why was this change necessary?

Avoid deprecation warning for `installed` state.

`[DEPRECATION WARNING]: State 'installed' is deprecated. Using state 'present' instead. This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.`

> How does it address the problem?

Updates state `installed` to `present` for ansible task.

> Are there any side effects?

None.