### PR TITLE
fix(settings): Add 'access-control-allow-origin' to CORS headers

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -4,6 +4,7 @@ see: https://docs.djangoproject.com/en/dev/ref/settings/
 """
 # Third Party Stuff
 import environ
+from corsheaders.defaults import default_headers
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -376,6 +377,17 @@ X_FRAME_OPTIONS = 'DENY'
 
 # django-log-request-id - Sending request id in response
 REQUEST_ID_RESPONSE_HEADER = 'REQUEST_ID'
+
+{%- if cookiecutter.add_django_cors_headers.lower() == 'y' %}
+
+# CORS
+# --------------------------------------------------------------------------
+CORS_ORIGIN_WHITELIST = env.list('CORS_ORIGIN_WHITELIST', default=[])
+CORS_ALLOW_HEADERS = default_headers + (
+    'access-control-allow-origin',
+)
+{%- endif %}
+
 
 {%- if cookiecutter.add_celery.lower() == 'y' %}
 

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -4,7 +4,9 @@ see: https://docs.djangoproject.com/en/dev/ref/settings/
 """
 # Third Party Stuff
 import environ
+{%- if cookiecutter.add_django_cors_headers.lower() == 'y' %}
 from corsheaders.defaults import default_headers
+{%- endif %}
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -44,18 +44,6 @@ MANAGERS = ADMINS
 # CORS
 # --------------------------------------------------------------------------
 CORS_ORIGIN_WHITELIST = env.list('CORS_ORIGIN_WHITELIST')
-CORS_ALLOW_HEADERS = (
-    'accept',
-    'accept-encoding',
-    'authorization',
-    'content-type',
-    'dnt',
-    'origin',
-    'user-agent',
-    'x-csrftoken',
-    'x-requested-with',
-    'access-control-allow-origin',
-)
 {%- endif %}
 
 {% if cookiecutter.add_django_auth_wall.lower() == 'y' %}

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -41,9 +41,21 @@ ADMINS = getaddresses([env('DJANGO_ADMINS')])
 MANAGERS = ADMINS
 {%- if cookiecutter.add_django_cors_headers.lower() == 'y' %}
 
-# cors
+# CORS
 # --------------------------------------------------------------------------
 CORS_ORIGIN_WHITELIST = env.list('CORS_ORIGIN_WHITELIST')
+CORS_ALLOW_HEADERS = (
+    'accept',
+    'accept-encoding',
+    'authorization',
+    'content-type',
+    'dnt',
+    'origin',
+    'user-agent',
+    'x-csrftoken',
+    'x-requested-with',
+    'access-control-allow-origin',
+)
 {%- endif %}
 
 {% if cookiecutter.add_django_auth_wall.lower() == 'y' %}


### PR DESCRIPTION
> Why was this change necessary?

Add `access-control-allow-origin` to `CORS_ALLOW_HEADERS` to allow pre-flight requests.

> How does it address the problem?

Added to support AJAX pre-flight requests.

> Are there any side effects?

None.
