### PR TITLE
refactor(settings/common) - do string comparison using "!=" instead of "is not"

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -527,6 +527,6 @@ RAVEN_CONFIG = {
 SITE_INFO = {
     'RELEASE_VERSION': RELEASE_VERSION,
 {%- if cookiecutter.use_sentry_for_error_reporting == 'y' %}
-    'IS_RAVEN_INSTALLED': RAVEN_CONFIG['dsn'] is not ''
+    'IS_RAVEN_INSTALLED': RAVEN_CONFIG['dsn'] != ''
 {%- endif %}
 }


### PR DESCRIPTION
> Why was this change necessary?

Travis builds are failing on flake8 due to "is not" operator for string comparison.
Travis error message:
```
./settings/common.py:474:27: F632 use ==/!= to compare str, bytes, and int literals
```
> How does it address the problem?


> Are there any side effects?
No.