### PR TITLE
docs - make markdown bold syntax in docs consistent

### DIFF
--- a/{{cookiecutter.github_repository}}/docs/api/endpoints.md
+++ b/{{cookiecutter.github_repository}}/docs/api/endpoints.md
@@ -10,14 +10,14 @@ For api overview and usages, check out [this page](overview.md).
 POST /api/auth/login
 ```
 
-**Parameters**
+__Parameters__
 
 Name     | Description
 ---------|-------------------------------------
 email    | email of the user. 
 password | password of the user.
 
-**Request**
+__Request__
 ```json
 {
     "email": "hello@example.com",
@@ -25,7 +25,7 @@ password | password of the user.
 }
 ```
 
-**Response**
+__Response__
 ```json
 
 Status: 200 OK
@@ -44,14 +44,14 @@ Status: 200 OK
 POST /api/auth/register
 ```
 
-**Parameters**
+__Parameters__
 
 Name     | Description
 ---------|-------------------------------------
 email    | email of the user. Errors out if email already registered.
 password | password of the user.
 
-**Request**
+__Request__
 ```json
 {
     "email": "hello@example.com",
@@ -59,7 +59,7 @@ password | password of the user.
 }
 ```
 
-**Response**
+__Response__
 ```json
 
 Status: 201 Created
@@ -78,14 +78,14 @@ Status: 201 Created
 POST /api/auth/password_change (requires authentication)
 ```
 
-**Parameters**
+__Parameters__
 
 Name             | Description
 -----------------|-------------------------------------
 current_password | Current password of the user.
 new_password     | New password of the user.
 
-**Request**
+__Request__
 ```json
 {
     "current_password": "NotSoSafePassword",
@@ -93,7 +93,7 @@ new_password     | New password of the user.
 }
 ```
 
-**Response**
+__Response__
 ```
 Status: 204 No-Content
 ```
@@ -107,20 +107,20 @@ Send an email to user if the email exist.
 POST /api/auth/password_reset
 ```
 
-**Parameters**
+__Parameters__
 
 Name  | Description
 ------|-------------------------------------
 email | (required) valid email of an existing user.
 
-**Request**
+__Request__
 ```json
 {
     "email": "hello@example.com"
 }
 ```
 
-**Response**
+__Response__
 ```json
 
 Status: 200 OK
@@ -138,7 +138,7 @@ Confirm password reset for the user using the token sent in email.
 POST /api/auth/password_reset_confirm
 ```
 
-**Parameters**
+__Parameters__
 
 Name          | Description
 --------------|-------------------------------------
@@ -146,7 +146,7 @@ new_password  | New password of the user
 token         | Token decoded from the url (verification link)
 
 
-**Request**
+__Request__
 ```json
 {
     "new_password": "new_pass",
@@ -154,12 +154,12 @@ token         | Token decoded from the url (verification link)
 }
 ```
 
-**Response**
+__Response__
 ```
 Status: 204 No-Content
 ```
 
-**Note**
+__Note__
 - The verification link uses the format of key `password-confirm` in `FRONTEND_URLS` dict in settings/common.
 
 

--- a/{{cookiecutter.github_repository}}/docs/backend/coding_rules.md
+++ b/{{cookiecutter.github_repository}}/docs/backend/coding_rules.md
@@ -23,15 +23,15 @@
 * All fields have `verbose_name`. Also `help_text` if needed to fully explain the field meaning.
 * All fields have explicit `blank` and `null` parameters. Use only those combinations, unless there a documented need of other thing:
 
-    **Normal fields** (IntegerField, DateField, ForeignKey, FileField...)
+    __Normal fields__ (IntegerField, DateField, ForeignKey, FileField...)
       - (optional) `null = True`, `blank = True`
       - (required) `null = False`, `blank = False`
 
-    **Text fields** (CharField, TextField, URLField...)
+    __Text fields__ (CharField, TextField, URLField...)
       - (optional) `null = False`, `blank = True`
       - (required) `null = False`, `blank = False`
 
-    **Boolean fields**:  
+    __Boolean fields__:  
       - (two values, T/F) `null = False`, `blank = True`
       - (three values, T/F/Null) `null = True`, `blank = True`
 

--- a/{{cookiecutter.github_repository}}/docs/backend/server_config.md
+++ b/{{cookiecutter.github_repository}}/docs/backend/server_config.md
@@ -94,7 +94,7 @@ DJANGO_AWS_STORAGE_BUCKET_NAME=<YOUR_BUCKET_NAME_HERE>
 ```
 
 
-**Note:**
+__Note:__
 - Use `--app=<heroku-app-name>` if you have more than one Heroku app configured in current project.
 - Update `travis.yml`, and add the `<heroku-app-name>` to automatically deploy to this configured Heroku app.
 {% endif %}

--- a/{{cookiecutter.github_repository}}/docs/index.md
+++ b/{{cookiecutter.github_repository}}/docs/index.md
@@ -14,8 +14,8 @@ __Version:__ {{ cookiecutter.version }}
 - [Server Setup & Configurations](backend/server_config.md)
 - [Coding Rules](backend/coding_rules.md)
 
-**NOTE:** This documentation changes frequently, checkout the [changelog](api/changelog.md) for detailed breaking changes and features added.
+__NOTE:__ This documentation changes frequently, checkout the [changelog](api/changelog.md) for detailed breaking changes and features added.
 
-Write your documentation using **Markdown** in `docs/` folder. Need help? Read mkdocs [documentation][mkdocs].
+Write your documentation using __Markdown__ in `docs/` folder. Need help? Read mkdocs [documentation][mkdocs].
 
 [mkdocs]: http://www.mkdocs.org/user-guide/writing-your-docs/


### PR DESCRIPTION
> Why was this change necessary?

Documentation uses a mix of `**` or `__` to bolden text. 

> How does it address the problem?

Most of the files used the `__` syntax. This replaces `**` with `__`.

> Are there any side effects?

No
