### PR TITLE
fix - remove raven import when sentry is not being used

### DIFF
--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/celery.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/celery.py
@@ -8,7 +8,9 @@ import raven
 from celery import Celery
 from django.conf import settings
 from dotenv import load_dotenv
+{%- if cookiecutter.use_sentry_for_error_reporting.lower() == 'y'%}
 from raven.contrib.celery import register_signal, register_logger_signal
+{%- endif %}
 
 # Set the default Django settings module for the 'celery' program.
 load_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), '.env'))


### PR DESCRIPTION
> Why was this change necessary?

Generator leaves a raven import in `celery.py` when sentry is not being used

> How does it address the problem?

Adds the conditional for when to keep the import

> Are there any side effects?

Yes.
