### PR TITLE
fix(celery.py): Sort import for celery

### DIFF
--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/celery.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/celery.py
@@ -9,7 +9,7 @@ from celery import Celery
 from django.conf import settings
 from dotenv import load_dotenv
 {%- if cookiecutter.use_sentry_for_error_reporting.lower() == 'y'%}
-from raven.contrib.celery import register_signal, register_logger_signal
+from raven.contrib.celery import register_logger_signal, register_signal
 {%- endif %}
 
 # Set the default Django settings module for the 'celery' program.


### PR DESCRIPTION
> Why was this change necessary?

Imports weren't sorted in celery.py file.

> How does it address the problem?

Sort imports

> Are there any side effects?

None
