### PR TITLE
feat(requirements): upgrade django-rest-swagger to 2.2.0

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -34,7 +34,7 @@ django-versatileimagefield==1.10
 # REST APIs
 # -------------------------------------
 djangorestframework==3.9.0
-django-rest-swagger==2.1.2
+django-rest-swagger==2.2.0
 {%- if cookiecutter.add_sass_with_django_compressor.lower() == 'y' %}
 
 # Static files

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/templates/rest_framework_swagger/index.html
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/templates/rest_framework_swagger/index.html
@@ -1,5 +1,0 @@
-{% raw %}{% extends "rest_framework_swagger/base.html" %}
-
-{% block logo %}
-<span id="logo" class="logo__title">API Playground</span>
-{% endblock %}{% endraw %}


### PR DESCRIPTION
> Why was this change necessary?

Keeping our project dependency upto date.

> How does it address the problem?

2.2.0 is a breaking change and this version doesn't include base.html and some
of the customizations we were doing ealier aren't available in the version. So
it's removed for simplicity.

> Are there any side effects?

The project name displayed in the nav bar won't be available, also the UI of new
swagger is changed from previous one.

closes #330