### PR TITLE
chore - upgrade django rest framework to latest

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -33,7 +33,7 @@ django-versatileimagefield==1.10
 
 # REST APIs
 # -------------------------------------
-djangorestframework==3.9.0
+djangorestframework==3.9.3
 django-rest-swagger==2.2.0
 
 # LOGGING


### PR DESCRIPTION
> Why was this change necessary?

Got a security alert from github

> How does it address the problem?

Upgrades to latest version

> Are there any side effects?

No. Version upgrade is backwards compatible
