### PR TITLE
chore(deps): update requirements to it's latest stable (except django)

### DIFF
--- a/{{cookiecutter.github_repository}}/.env.sample
+++ b/{{cookiecutter.github_repository}}/.env.sample
@@ -46,7 +46,7 @@
 {%- if cookiecutter.add_django_cors_headers.lower() == 'y' %}
 # CORS
 # ==============================
-# CORS_ORIGIN_WHITELIST=localhost:8000,127.0.0.1:9000,example.com
+# CORS_ORIGIN_WHITELIST=http://localhost:8000,http://127.0.0.1:9000,https://example.com
 {%- endif %}
 
 {% if cookiecutter.use_sentry_for_error_reporting == "y" -%}

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -4,12 +4,12 @@ Django==2.1.7
 
 # Configuration
 # -------------------------------------
-argon2-cffi==18.3.0
+argon2-cffi==19.1.0
 django-environ==0.4.5
 django-sites==0.10
-python-dotenv==0.10.0
+python-dotenv==0.10.2
 {%- if cookiecutter.add_django_cors_headers.lower() == 'y' %}
-django-cors-headers==2.4.0
+django-cors-headers==3.0.1
 {%- endif %}
 
 {% if cookiecutter.enable_whitenoise.lower() == 'y' -%}
@@ -20,20 +20,20 @@ whitenoise==4.1.2
 
 # Extensions
 # -------------------------------------
-pytz==2018.7
+pytz==2019.1
 
 # Models
 # -------------------------------------
-psycopg2-binary==2.7.6.1
+psycopg2-binary==2.8.2
 
-Pillow==5.3.0
-django-extensions==2.1.4
+Pillow==6.0.0
+django-extensions==2.1.7
 django-uuid-upload-path==1.0.0
 django-versatileimagefield==1.10
 
 # REST APIs
 # -------------------------------------
-djangorestframework==3.9.3
+djangorestframework==3.9.4
 django-rest-swagger==2.2.0
 
 # LOGGING
@@ -47,14 +47,14 @@ mkdocs==1.0.4
 {% if cookiecutter.use_sentry_for_error_reporting == "y" -%}
 # Raven is the Sentry client
 # --------------------------
-raven==6.9.0
+raven==6.10.0
 {%- endif %}
 
 {%- if cookiecutter.add_celery.lower() == "y" %}
 
 # Async Tasks
 # -------------------------------------
-celery[redis]==4.2.1
+celery[redis]==4.3.0
 {%- endif %}
 
 # Auth Stuff

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -2,21 +2,21 @@
 
 # Documentation
 # -------------------------------------
-isort==4.3.4
+isort==4.3.20
 
 # Debugging
 # -------------------------------------
 django-debug-toolbar==1.11
-ipdb==0.11
+ipdb==0.12
 
 # Testing and coverage
 # -------------------------------------
-pytest==4.0.1
-pytest-django==3.4.4
-pytest-cov==2.6.0
+pytest==4.5.0
+pytest-django==3.4.8
+pytest-cov==2.7.1
 django-dynamic-fixture==2.0.0
 flake8-mypy==17.8.0
-pytest-mock==1.10.0
+pytest-mock==1.10.4
 
 # Versioning
 # -------------------------------------

--- a/{{cookiecutter.github_repository}}/requirements/production.txt
+++ b/{{cookiecutter.github_repository}}/requirements/production.txt
@@ -5,7 +5,7 @@
 # Static Files and Media Storage
 # -------------------------------------
 django-storages==1.7.1
-boto3==1.9.62
+boto3==1.9.156
 
 # Caching
 # -------------------------------------


### PR DESCRIPTION
> Why was this change necessary?

To keep things upto date. Django will be updated in another PR.

> How does it address the problem?

...

> Are there any side effects?

django-cors-headers now recommends domains with schemes, so example is updated

add your text here...