### PR TITLE
upgrade(requirements/dev): Upgrade ansible 2.5.0 -> 2.5.15

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -25,7 +25,7 @@ bumpversion==0.5.3
 # Deployment and Tasks
 # -------------------------------------
 fabric3==1.14.post1
-{% if cookiecutter.add_ansible.lower() == 'y' %}ansible==2.5.0{% endif %}
+{% if cookiecutter.add_ansible.lower() == 'y' %}ansible==2.5.15{% endif %}
 
 {%- if cookiecutter.add_pre_commit.lower() == 'y' %}
 # Code quality


### PR DESCRIPTION
> Why was this change necessary?

CVE-2019-3828
critical severity
Vulnerable versions: < 2.5.15
Patched version: 2.5.15

Ansible fetch module before versions 2.5.15, 2.6.14, 2.7.8 has a path traversal vulnerability which allows copying and overwriting files outside of the specified destination in the local ansible controller host, by not restricting an absolute path.

CVE-2018-10855
high severity
Vulnerable versions: >= 2.5.0, < 2.5.5
Patched version: 2.5.5

Ansible 2.5 prior to 2.5.5, and 2.4 prior to 2.4.5, do not honor the no_log task flag for failed tasks. When the no_log flag has been used to protect sensitive data passed to a task from being logged, and that task does not run successfully, Ansible will expose sensitive data in log files and on the terminal of the user running Ansible.

> How does it address the problem?

Upgrades Ansible to 2.0.15

> Are there any side effects?

None
