### PR TITLE
Fix celerybeat run dir

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/defaults/main.yml
@@ -6,7 +6,8 @@ celery_log_dir: /var/log/celery/{{ project_namespace }}
 celery_log_file: "{{ celery_log_dir }}/celery.log"
 celerybeat_log_file: "{{ celery_log_dir }}/celerybeat.log"
 celery_log_level: "INFO"
-celerybeat_schedule_dir: /var/run/celery
+celery_runtime_dir: celery
+celerybeat_schedule_dir: /var/run/{{ celery_runtime_dir }}
 celerybeat_schedule_file: "{{ celerybeat_schedule_dir }}/schedule-{{ project_namespace }}.db"
 celery_pid_file: /tmp/celery-{{ project_namespace }}.pid
 celerybeat_pid_file: /tmp/celerybeat-{{ project_namespace }}.pid

--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/tasks/main.yml
@@ -14,10 +14,6 @@
   become: false
   tags: ['celery']
 
-- name: make sure celerybeat schedule directory exists
-  file: path={{ celerybeat_schedule_dir }} state=directory owner={{celery_user}} group={{celery_group}} mode=751 recurse=yes
-  tags: ['configure', 'celery']
-
 - name: ensure celery package is installed
   pip: name=celery state=present executable={{ venv_path }}/bin/pip
   become: false

--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/templates/celerybeat.service.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/templates/celerybeat.service.j2
@@ -5,6 +5,7 @@ After=network.target
 
 [Service]
 User={{ celery_user }}
+RuntimeDirectory={{ celery_runtime_dir }}
 Group={{ celery_group }}
 Restart=always
 WorkingDirectory={{ project_path }}


### PR DESCRIPTION
> Why was this change necessary?

When the server gets restarted, /var/run/celery doesn;t exist and server is on 100% CPU usage. 

> How does it address the problem?

systemd services creates the directly when started and removes when its stopped.

> Are there any side effects?

Not known as of now