### PR TITLE
refractor(urls): update urls.py to use new 'path' and 're_path'

### DIFF
--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/urls.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/urls.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """Root url routering file.
 
 You should put the url config in their respective app putting only a
@@ -6,10 +7,10 @@ refernce to them here.
 
 # Third Party Stuff
 from django.conf import settings
-from django.conf.urls import include, url
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.views.generic import TemplateView
+from django.urls import include, path, re_path
 
 from . import api_urls
 from .base import views as base_views
@@ -21,30 +22,30 @@ handler500 = base_views.server_error
 # Top Level Pages
 # ==============================================================================
 urlpatterns = [
-    url(r'^$', TemplateView.as_view(template_name='pages/home.html'), name='home'),
-    url(r'^about/$', TemplateView.as_view(template_name='pages/about.html'), name='about'),
+    path('', TemplateView.as_view(template_name='pages/home.html'), name='home'),
+    path('about/', TemplateView.as_view(template_name='pages/about.html'), name='about'),
     # Your stuff: custom urls go here
 ]
 
 urlpatterns += [
 
-    url(r'^(?P<filename>(robots.txt)|(humans.txt))$',
-        base_views.root_txt_files, name='root-txt-files'),
+    re_path(r'^(?P<filename>(robots.txt)|(humans.txt))$',
+            base_views.root_txt_files, name='root-txt-files'),
 
     # Rest API
-    url(r'^api/', include(api_urls)),
+    path('api/', include(api_urls)),
 
     # Django Admin
-    url(r'^{}/'.format(settings.DJANGO_ADMIN_URL), admin.site.urls),
+    path('{}/'.format(settings.DJANGO_ADMIN_URL), admin.site.urls),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.API_DEBUG:
     urlpatterns += [
         # Browsable API
-        url('^schema/$', api_schemas.schema_view, name='schema'),
-        url(r'^api-playground/$', api_schemas.swagger_schema_view, name='api-playground'),
-        url(r'^api/auth-n/', include('rest_framework.urls', namespace='rest_framework')),
+        path('schema/', api_schemas.schema_view, name='schema'),
+        path('api-playground/', api_schemas.swagger_schema_view, name='api-playground'),
+        path('api/auth-n/', include('rest_framework.urls', namespace='rest_framework')),
     ]
 
 if settings.DEBUG:
@@ -52,16 +53,14 @@ if settings.DEBUG:
     from django.urls import get_callable
 
     urlpatterns += [
-        url(r'^400/$', dj_default_views.bad_request, kwargs={'exception': Exception('Bad Request!')}),
-        url(r'^403/$', dj_default_views.permission_denied, kwargs={'exception': Exception('Permission Denied!')}),
-        url(r'^403_csrf/$', get_callable(settings.CSRF_FAILURE_VIEW)),
-        url(r'^404/$', dj_default_views.page_not_found, kwargs={'exception': Exception('Not Found!')}),
-        url(r'^500/$', handler500),
+        path('400/', dj_default_views.bad_request, kwargs={'exception': Exception('Bad Request!')}),
+        path('403/', dj_default_views.permission_denied, kwargs={'exception': Exception('Permission Denied!')}),
+        path('403_csrf/', get_callable(settings.CSRF_FAILURE_VIEW)),
+        path('404/', dj_default_views.page_not_found, kwargs={'exception': Exception('Not Found!')}),
+        path('500/', handler500),
     ]
 
     # Django Debug Toolbar
-    try:
+    if 'debug_toolbar' in settings.INSTALLED_APPS:
         import debug_toolbar
-        urlpatterns += [url(r'^__debug__/', include(debug_toolbar.urls)), ]
-    except ImportError:
-        pass
+        urlpatterns += [path('__debug__/', include(debug_toolbar.urls))]


### PR DESCRIPTION
> Why was this change necessary?

- Makes thing more clean.
- 'url()' is depreciated, so it's better to remove it.
- Use 'django.urls' instead of 'django.conf.urls'

> How does it address the problem?

Use 'path()' and 're_path()' where necessary. 

> Are there any side effects?

Not that i'm aware of.
