### PR TITLE
Update celery concurrency to default to number of CPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.x]
 
+- Update celery concurrency to default to number of CPUs ([@theskumar])
 - Upgrade to Postgres 11 and Postgis 2.5. ([@CuriousLearner])
 - Upgrade to Postgres 10 and Postgis 2.4. ([@CuriousLearner])
 - Add task for compiling static string translations. ([@CuriousLearner])

--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/defaults/main.yml
@@ -1,7 +1,6 @@
 {% raw %}---
 celery_user: www-data
 celery_group: www-data
-celery_concurrency: 4
 celery_log_dir: /var/log/celery/{{ project_namespace }}
 celery_log_file: "{{ celery_log_dir }}/celery.log"
 celerybeat_log_file: "{{ celery_log_dir }}/celerybeat.log"

--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/templates/celery.service.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/templates/celery.service.j2
@@ -10,10 +10,10 @@ Type=forking
 Restart=always
 WorkingDirectory={{ project_path }}
 ExecStart={{ venv_path }}/bin/celery multi start worker-{{ project_namespace }} -A {{ project_name }} -l {{ celery_log_level }} \
-    --concurrency={{ celery_concurrency }} --logfile={{ celery_log_file }} --pidfile={{ celery_pid_file }}  --schedule={{ celerybeat_schedule_file}}
+    --logfile={{ celery_log_file }} --pidfile={{ celery_pid_file }}  --schedule={{ celerybeat_schedule_file}}
 ExecStop={{ venv_path }}/bin/celery multi stopwait worker-{{ project_namespace }} --pidfile={{ celery_pid_file }}
 ExecReload={{ venv_path }}/bin/celery multi restart worker-{{ project_namespace }} -A {{ project_name }} -l {{ celery_log_level }} \
-    --concurrency={{ celery_concurrency }} --logfile={{ celery_log_file }} --pidfile={{ celery_pid_file }}  --schedule={{ celerybeat_schedule_file}}
+    --logfile={{ celery_log_file }} --pidfile={{ celery_pid_file }}  --schedule={{ celerybeat_schedule_file}}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
> Why was this change necessary?

The default concurrency was set to 4 which is generally too high for dev/QA instances.

> How does it address the problem?

Celery automatically configures the concurrency depending on the number of CPUs available if omitted and this PR does that. https://docs.celeryproject.org/en/latest/userguide/workers.html#concurrency

> Are there any side effects?

nope. The concurrency can be added back as needed. 
