### PR TITLE
fix(nginx): let nginx configure it's no. of workers based on no. of CPUs

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
@@ -1,6 +1,6 @@
 ngnix_listen: '443 http2 ssl'
 nginx_user: 'www-data'
-nginx_worker_processes: 1
+nginx_worker_processes: auto
 nginx_worker_connections: 1024
 nginx_client_max_body_size: '10M'
 


### PR DESCRIPTION
> Why was this change necessary?

Nginx allows automatic configuration of its workers based on the no. of available CPUs on the deployed, this will allow Nginx to run at its optimal performance in a prod like environment. 

> How does it address the problem?

Let Nginx decide and configure it's number of workers based on the no. of available CPUs https://nginx.org/en/docs/ngx_core_module.html#worker_processes

> Are there any side effects?

No. 
