### PR TITLE
refractor: improve variable naming and standardize log and venv dirs

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/hosts
+++ b/{{cookiecutter.github_repository}}/provisioner/hosts
@@ -3,8 +3,8 @@
 
 [vagrant:vars]
 vm=1
-deploy_environment=vagrant
-project_namespace={% raw %}{{ project_name }}-{{ deploy_environment }}{% endraw %}
+deploy_env=vagrant
+project_namespace={% raw %}{{ project_name }}-{{ deploy_env }}{% endraw %}
 user=vagrant
 project_path=/home/vagrant/{{ cookiecutter.github_repository }}
 venv_path=/home/vagrant/venv
@@ -21,11 +21,11 @@ dev.{{ cookiecutter.main_module }}.com
 
 [dev:vars]
 vm=0
-deploy_environment=dev
+deploy_env=dev
 user=ubuntu
-project_namespace={% raw %}{{ project_name }}-{{ deploy_environment }}{% endraw %}
-project_path=/home/ubuntu/{% raw %}{{ deploy_environment }}{% endraw %}/{{ cookiecutter.github_repository }}
-venv_path=/home/ubuntu/{% raw %}{{ deploy_environment }}/{{ project_name }}-venv{% endraw %}
+project_namespace={% raw %}{{ project_name }}-{{ deploy_env }}{% endraw %}
+project_path=/home/ubuntu/{% raw %}{{ deploy_env }}{% endraw %}/{{ cookiecutter.github_repository }}
+venv_path={% raw %}{{ project_path }}/venv{% endraw %}
 use_letsencrypt={{ 'True' if cookiecutter.letsencrypt.lower() == 'y' else 'False' }}
 letsencrypt_email={{ cookiecutter.letsencrypt_email }}
 django_requirements_file=requirements.txt
@@ -38,11 +38,11 @@ qa.{{ cookiecutter.main_module }}.com
 
 [qa:vars]
 vm=0
-deploy_environment=qa
+deploy_env=qa
 user=ubuntu
-project_namespace={% raw %}{{ project_name }}-{{ deploy_environment }}{% endraw %}
-project_path=/home/ubuntu/{% raw %}{{ deploy_environment }}{% endraw %}/{{ cookiecutter.github_repository }}
-venv_path=/home/ubuntu/{% raw %}{{ deploy_environment }}/{{ project_name }}-venv{% endraw %}
+project_namespace={% raw %}{{ project_name }}-{{ deploy_env }}{% endraw %}
+project_path=/home/ubuntu/{% raw %}{{ deploy_env }}{% endraw %}/{{ cookiecutter.github_repository }}
+venv_path={% raw %}{{ project_path }}/venv{% endraw %}
 use_letsencrypt={{ 'True' if cookiecutter.letsencrypt.lower() == 'y' else 'False' }}
 letsencrypt_email={{ cookiecutter.letsencrypt_email }}
 django_requirements_file=requirements.txt
@@ -54,11 +54,11 @@ domain_name=qa.{{ cookiecutter.main_module }}.com
 
 [production:vars]
 vm=0
-deploy_environment=prod
+deploy_env=prod
 user=ubuntu
-project_namespace={% raw %}{{ project_name }}-{{ deploy_environment }}{% endraw %}
-project_path=/home/ubuntu/{% raw %}{{ deploy_environment }}{% endraw %}/{{ cookiecutter.github_repository }}
-venv_path=/home/ubuntu/{% raw %}{{ deploy_environment }}/{{ project_name }}-venv{% endraw %}
+project_namespace={% raw %}{{ project_name }}-{{ deploy_env }}{% endraw %}
+project_path=/home/ubuntu/{% raw %}{{ deploy_env }}{% endraw %}/{{ cookiecutter.github_repository }}
+venv_path={% raw %}{{ project_path }}/venv{% endraw %}
 use_letsencrypt={{ 'True' if cookiecutter.letsencrypt.lower() == 'y' else 'False' }}
 letsencrypt_email={{ cookiecutter.letsencrypt_email }}
 django_requirements_file=requirements.txt

--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/defaults/main.yml
@@ -1,13 +1,13 @@
 {% raw %}---
 celery_user: www-data
 celery_group: www-data
-celery_log_dir: /var/log/celery/{{ project_namespace }}
-celery_log_file: "{{ celery_log_dir }}/celery.log"
-celerybeat_log_file: "{{ celery_log_dir }}/celerybeat.log"
+celery_log_dir: /var/log/celery
+celery_log_file: "{{ celery_log_dir }}/{{ project_namespace }}.log"
+celerybeat_log_file: "{{ celery_log_dir }}/{{ project_namespace }}.celerybeat.log"
 celery_log_level: "INFO"
 celery_runtime_dir: celery
-celerybeat_schedule_dir: /var/run/{{ celery_runtime_dir }}
+celerybeat_schedule_dir: "/var/run/{{ celery_runtime_dir }}"
 celerybeat_schedule_file: "{{ celerybeat_schedule_dir }}/schedule-{{ project_namespace }}.db"
-celery_pid_file: /tmp/celery-{{ project_namespace }}.pid
-celerybeat_pid_file: /tmp/celerybeat-{{ project_namespace }}.pid
+celery_pid_file: "/tmp/celery-{{ project_namespace }}.pid"
+celerybeat_pid_file: "/tmp/celerybeat-{{ project_namespace }}.pid"
 {% endraw %}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
@@ -5,7 +5,7 @@ nginx_worker_connections: 1024
 nginx_client_max_body_size: '10M'
 
 {% raw %}
-nginx_conf_file_name: '{{ project_name }}-{{ deploy_environment }}'
+nginx_conf_file_name: '{{ project_namespace }}'
 
 # SSL common configurations
 ssl_cert_dir: '/etc/nginx/ssl'
@@ -29,6 +29,6 @@ error_log_file: '/var/log/nginx/{{ domain_name }}.error.log'
 
 # htpasswsd
 # docs username, password
-htpasswd_file_path: '/etc/nginx/.htpasswd-{{ deploy_environment }}'
-nginx_docs_username: '{{ project_name }}-docs'
-nginx_docs_password: '{{ project_name }}-1234!'{% endraw %}
+htpasswd_file_path: '/etc/nginx/.htpasswd-{{ project_namespace }}'{% endraw %}
+nginx_docs_username: '{{ cookiecutter.main_module|truncate(3, True, '') }}'
+nginx_docs_password: '{{ cookiecutter.main_module|title|truncate(3, True, '') }}1234!'

--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/templates/site.443.conf.j2
@@ -52,7 +52,7 @@ server {
 
     # Setup named location for Django requests and handle proxy details
     location / {
-        uwsgi_pass unix:///tmp/django-{{ domain_name }}-uwsgi.sock;
+        uwsgi_pass unix:///tmp/uwsgi-{{ project_namespace }}.sock;
         include /etc/nginx/uwsgi_params;
 
         # set correct scheme

--- a/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 pg_hstore: False
 pg_gis: False
-pg_db: '{% raw %}{{ project_name }}-{{ deploy_environment }}{% endraw %}'
+pg_db: '{% raw %}{{ project_namespace }}{% endraw %}'
 pg_user: dev
 pg_password: password

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/defaults/main.yml
@@ -1,6 +1,6 @@
 {% raw %}---
 pg_hstore: False
-pg_db: '{{ project_name }}-{{ deploy_environment }}'
+pg_db: "{{ project_namespace }}"
 pg_user: dev
 pg_password: password
 django_requirements_file: requirements.txt
@@ -15,8 +15,9 @@ uwsgi_timeout: 30
 uwsgi_keepalive: 2
 uwsgi_loglevel: info
 uwsgi_conf_path: /etc/uwsgi-emperor/vassals
-uwsgi_socket: /tmp/django-{{ domain_name }}-uwsgi.sock
-uwsgi_pid_file: /tmp/django-{{ domain_name }}-wsgi.pid
+uwsgi_socket: "/tmp/uwsgi-{{ project_namespace }}.sock"
+uwsgi_pid_file: "/tmp/uwsgi-{{ project_namespace }}.pid"
 
-project_log_dir: /var/log/django/{{ deploy_environment }}/{{ project_name}}
+uwsgi_log_dir: /var/log/uwsgi
+uwsgi_log_file: "{{ uwsgi_log_dir }}/{{ project_namespace }}.log"
 {% endraw %}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/uwsgi-setup.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/uwsgi-setup.yml
@@ -23,17 +23,17 @@
 
 - name: copy django-uwsgi logrotate
   template: src=django.logrotate.j2
-            dest=/etc/logrotate.d/uwsgi-{{ deploy_environment}}-{{project_name}}-django
+            dest=/etc/logrotate.d/uwsgi-{{ project_namespace }}
             mode=644
   tags: ['configure']
 
-- name: make sure log directory exists
-  file: path={{ project_log_dir }} state=directory owner={{uwsgi_user}} group={{uwsgi_group}} mode=751 recurse=yes
+- name: make sure uwsgi log directory exists
+  file: path={{ uwsgi_log_dir }} state=directory owner={{uwsgi_user}} group={{uwsgi_group}} mode=751 recurse=yes
   tags: ['configure']
 
 - name: ensure django app config is added as uwsgi vassal
   template: src=django.uwsgi.ini.j2
-            dest={{ uwsgi_conf_path }}/django-{{project_name}}-{{ deploy_environment }}.ini
+            dest={{ uwsgi_conf_path }}/{{project_namespace }}.ini
             mode=644
   tags: ['deploy']
   register: uwsgiconf

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/django.logrotate.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/django.logrotate.j2
@@ -1,4 +1,4 @@
-{% raw %}"{{project_log_dir}}/uwsgi.log" {
+{% raw %}"{{ uwsgi_log_file }}" {
   copytruncate
   daily
   rotate 5

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/django.uwsgi.ini.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/django.uwsgi.ini.j2
@@ -23,7 +23,7 @@ autoload=true
 no-orphans=true
 chmod-socket=660
 log-date=true
-logto = {{project_log_dir}}/uwsgi.log{% endraw %}
+logto={{ uwsgi_log_file }}{% endraw %}
 
 
 # os write errors


### PR DESCRIPTION
> Why was this change necessary?

To simplify cookiecutter naming and folders. 

> How does it address the problem?

make the log directories consistent.

> Are there any side effects?

The proposes new directory paths, which might not be very obvious of devs already used to current directories.
