### PR TITLE
feat(users/auth) - Use standard Bearer authentication scheme

### DIFF
--- a/{{cookiecutter.github_repository}}/docs/api/0-overview.md
+++ b/{{cookiecutter.github_repository}}/docs/api/0-overview.md
@@ -1,5 +1,19 @@
 This describes the resources that make up the official {{ cookiecutter.project_name }} API v1.
 
+## Authentication
+
+For clients to authenticate, the token key should be included in the Authorization HTTP header. The key should be prefixed by the string literal `Bearer`, with whitespace separating the two strings. For example:
+
+```
+Authorization: Bearer 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b
+```
+Unauthenticated responses that are denied permission will result in an `HTTP 401 Unauthorized` response.
+
+An example request:
+```bash
+curl -X GET http://127.0.0.1:8000/api/example/ -H `Authorization: Bearer 9944b09199c62bcf9418ad846dd0e4bbdfc6ee4b`
+```
+
 ## Current Version
 
 By default, all requests receive the `1.0` version of the API. We encourage you to explicitly request this version via the Accept header.

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/backends.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/backends.py
@@ -32,7 +32,7 @@ class UserTokenAuthentication(BaseAuthentication):
     data stored in the token.
     """
 
-    auth_rx = re.compile(r"^Token (.+)$")
+    auth_rx = re.compile(r"^Bearer (.+)$")
 
     def authenticate(self, request):
         if "HTTP_AUTHORIZATION" not in request.META:
@@ -48,4 +48,4 @@ class UserTokenAuthentication(BaseAuthentication):
         return (user, token)
 
     def authenticate_header(self, request):
-        return 'Token realm="api"'
+        return 'Bearer realm="api"'


### PR DESCRIPTION
> Why was this change necessary?

`Token` scheme currently used is not the HTTP auth standard
https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#Authentication_schemes

> How does it address the problem?

- Changes to the standard Bearer auth scheme.
- Adds documentation for authentication

> Are there any side effects?

Yes. Clients for the new projects would now have to authenticate using the Bearer scheme instead of the token one.
