### PR TITLE
chore - update django, django rest framework, cors headers

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -1,6 +1,6 @@
 # Core Stuff
 # -------------------------------------
-Django==2.2.4
+Django==2.2.6
 
 # Configuration
 # -------------------------------------
@@ -9,7 +9,7 @@ django-environ==0.4.5
 django-sites==0.10
 python-dotenv==0.10.3
 {%- if cookiecutter.add_django_cors_headers.lower() == 'y' %}
-django-cors-headers==3.0.2
+django-cors-headers==3.1.1
 {%- endif %}
 
 {% if cookiecutter.enable_whitenoise.lower() == 'y' -%}
@@ -33,7 +33,7 @@ django-versatileimagefield==1.10
 
 # REST APIs
 # -------------------------------------
-djangorestframework==3.9.4
+djangorestframework==3.10.3
 django-rest-swagger==2.2.0
 
 # LOGGING


### PR DESCRIPTION
> Why was this change necessary?

updated django, drf and django cors headers
drf 3.10 has better affordances for auto-generated docs. So, this PR is like a pre-cursor for that change

> Are there any side effects?

No