### PR TITLE
chore(): Upgrade django-versatileimagefield to 1.11

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -29,7 +29,7 @@ psycopg2-binary==2.8.2
 Pillow==6.2.0
 django-extensions==2.1.9
 django-uuid-upload-path==1.0.0
-django-versatileimagefield==1.10
+django-versatileimagefield==1.11
 
 # REST APIs
 # -------------------------------------


### PR DESCRIPTION
> Why was this change necessary?

Upgrade django-versatileimagefield to 1.11

> How does it address the problem?

Upgrade django-versatileimagefield to 1.11

> Are there any side effects?

None.
