### PR TITLE
fix(provisioner) - typo for letsencrypt_challenge_root in defaults

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/nginx/defaults/main.yml
@@ -12,7 +12,7 @@ ssl_cert_dir: '/etc/nginx/ssl'
 ssl_forward_secrecy_key_path: /etc/nginx/dhparam.pem
 ssl_forward_secrecy_key_length: 2048
 letsencrypt_ssl_cert_dir: '/etc/letsencrypt/live/{{ domain_name }}'
-letsencrypt_challange_root: '/app/certbot'
+letsencrypt_challenge_root: '/app/certbot'
 letsencrypt_email: 'webmaster@{{ domain_name }}'
 ssl_certificate: '{{ ssl_cert_dir }}/{{ domain_name }}/fullchain.pem'
 ssl_certificate_key: '{{ ssl_cert_dir }}/{{ domain_name }}/privkey.pem'


### PR DESCRIPTION
> Why was this change necessary?

this typo was fixed in in our tasks but not in the defaults. Hence, our provisioner scripts are failing now.

> How does it address the problem?

Fixes the typo in defaults nginx configuration as well

> Are there any side effects?

Nope. I have verified that we can succesfully configure a server now.
