### PR TITLE
chore - use actively maintained bump2version instead of bumpversion

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -20,7 +20,7 @@ pytest-mock==1.10.4
 
 # Versioning
 # -------------------------------------
-bumpversion==0.5.3
+bump2version==0.5.11
 
 # Deployment and Tasks
 # -------------------------------------


### PR DESCRIPTION
> Why was this change necessary?

bumpversion is no longer actively maintained. There are some discussions going on to get bump2version's updates to more users by possibly merging the two projects.
https://github.com/c4urself/bump2version/issues/86

> How does it address the problem?

Uses bump2version which is a drop in replacement

> Are there any side effects?

No.
