### PR TITLE
fix(swagger) - include default schema class settings for swagger ui

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -103,6 +103,7 @@ REST_FRAMEWORK = {
         # Mainly used for api debug.
         "rest_framework.authentication.SessionAuthentication",
     ),
+    "DEFAULT_SCHEMA_CLASS": 'rest_framework.schemas.coreapi.AutoSchema',
     "EXCEPTION_HANDLER": "{{ cookiecutter.main_module }}.base.exceptions.exception_handler",
 }
 


### PR DESCRIPTION
> Why was this change necessary?

The base project generated errors out for swagger ui view at `/api-playground` with the error `'AutoSchema' object has no attribute 'get_link'`

> How does it address the problem?

Fix specified here on this issue:
https://github.com/encode/django-rest-framework/issues/6809

> Are there any side effects?

No