### PR TITLE
set python3 as default interpretor for ansible

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/vars.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/vars.yml
@@ -4,3 +4,4 @@ project_repo_url: git@github.com:{{ cookiecutter.github_username }}/{{ cookiecut
 project_repo_remote: origin
 repo_version: master
 pg_gis: {{ 'True' if cookiecutter.postgis.lower() == 'y' else 'False' }}
+ansible_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
> Why was this change necessary?

ubuntu 18.04 comes with python3 as default and ansible look for python2 and fails. To fix that we have to install python2 on the server or create an alias of python to python3

> How does it address the problem?

This change will tell ansible to look for python3 instead of python2 by default

> Are there any side effects?

It won't work on old OS which have python2 as default, to make that work we have to remove this setting
