### PR TITLE
feat(provisioner) - install python3 psycopg2

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/postgresql/tasks/main.yml
@@ -11,7 +11,7 @@
 
 - name: Install postgresql packages
   apt:
-    pkg: ['postgresql-11', 'postgresql-contrib', 'python-psycopg2']
+    pkg: ['postgresql-11', 'postgresql-contrib', 'python3-psycopg2']
     state: present
 
 - name: Install postgis packages


### PR DESCRIPTION

> Why was this change necessary?
With default interpreter switched to python3, install python3 psycopg2 instead of python2

> How does it address the problem?
Installs python3 psycopg2

> Are there any side effects?
Yes. psycopg2 will no longer be available for python 2