### PR TITLE
fix(travis): Remove docker and install Postgres 11 directly on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,6 @@ cache:
   directories:
   - node_modules # NPM packages
 
-services:
-  - docker
-
-env:
-  global:
-  - PGHOST=localhost
-  - PGUSER=postgres
-  - PGPORT=5433
-
 before_install:
   - sudo apt-get update
   - sudo apt-get --yes remove postgresql\*
@@ -28,14 +19,9 @@ before_install:
   - sudo cp /etc/postgresql/{9.6,11}/main/pg_hba.conf
   - sudo service postgresql restart 11
 
-#before_install:
-#  - sudo service postgresql stop
-#  - docker pull postgres:11
-#  - docker run --rm --name pg-docker -d -p ${PGPORT}:5432 --tmpfs /var/lib/postgresql/data:rw postgres:11
-#  - docker ps
-
 services:
   - postgresql
+
 addons:
   postgresql: "11.2"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ env:
   global:
   - PGHOST=localhost
   - PGUSER=postgres
-  - PGPORT=5432
+  - PGPORT=5433
 
 before_install:
   - sudo service postgresql stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,22 @@ env:
   - PGPORT=5433
 
 before_install:
-  - sudo service postgresql stop
-  - docker pull postgres:11
-  - docker run --rm --name pg-docker -d -p ${PGPORT}:5432 --tmpfs /var/lib/postgresql/data:rw postgres:11
-  - docker ps
+  - sudo apt-get update
+  - sudo apt-get --yes remove postgresql\*
+  - sudo apt-get install -y postgresql-11 postgresql-client-11
+  - sudo cp /etc/postgresql/{9.6,11}/main/pg_hba.conf
+  - sudo service postgresql restart 11
+
+#before_install:
+#  - sudo service postgresql stop
+#  - docker pull postgres:11
+#  - docker run --rm --name pg-docker -d -p ${PGPORT}:5432 --tmpfs /var/lib/postgresql/data:rw postgres:11
+#  - docker ps
+
+services:
+  - postgresql
+addons:
+  postgresql: "11.2"
 
 install:
   - pip install cookiecutter==1.6.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ cache:
   directories:
   - node_modules # NPM packages
 
+env:
+  global:
+  - PGHOST=localhost
+  - PGUSER=postgres
+  - PGPORT=5433
+
 before_install:
   - sudo apt-get update
   - sudo apt-get --yes remove postgresql\*

--- a/{{cookiecutter.github_repository}}/.travis.yml
+++ b/{{cookiecutter.github_repository}}/.travis.yml
@@ -10,8 +10,8 @@ python:
 node_js:
   - "10"
 
-services:
-  - docker
+addons:
+  postgresql: "11.2"
 
 {%- if cookiecutter.postgis.lower() == 'y' %}
 addons:
@@ -26,7 +26,7 @@ cache:
   - node_modules  # NPM packages
 
 services:
-  - docker
+  - postgresql
 
 env:
   global:
@@ -34,7 +34,7 @@ env:
   - PGHOST=localhost
   - PGUSER=postgres
   - PGPASS=''
-  - PGPORT=5432
+  - PGPORT=5433
 {%- if cookiecutter.postgis.lower() == 'y' %}
   - DATABASE_URL=postgis://${PGUSER}:${PGPASS}@${PGHOST}:${PGPORT}/${PGDATABASE}
   - POSTGRES_IMAGE=mdillon/postgis:11
@@ -44,9 +44,11 @@ env:
 {%- endif %}
 
 before_install:
-  - sudo service postgresql stop
-  - docker run --rm --name pg-docker -d -p ${PGPORT}:5432 --tmpfs /var/lib/postgresql/data:rw ${POSTGRES_IMAGE}
-  - docker ps
+  - sudo apt-get update
+  - sudo apt-get --yes remove postgresql\*
+  - sudo apt-get install -y postgresql-11 postgresql-client-11
+  - sudo cp /etc/postgresql/{9.6,11}/main/pg_hba.conf
+  - sudo service postgresql restart 11
 
 before_cache:
   - rm -f $HOME/.cache/pip/log/debug.log


### PR DESCRIPTION
> Why was this change necessary?

All the recent Travis CI builds on django-init are breaking and the master branch is also failing. Also, the projects generated through the cookiecutter will consequently have failed CI tests as the pytest wasn't able to connect to the Postgres database running within the docker container.

> How does it address the problem?

The Postgres is now installed directly on Travis and all the config are copied from Postgres 9 (which is installed by default) to Postgres 11. Given that now we've two different Postgres version on Travis, Postgres 11 will run on the next available port from the default port of 5432, which is 5433.

> Are there any side effects?

None.
