### PR TITLE
Add support for Django 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.x]
 
+- Add support for Django 3.x ([@CuriousLearner]).
 - Remove support for Circle CI ([@theskumar])
 - vendor media type for accept headers. ([@tucosaurus]) 
 - Add black in pre-commit and also formatted exiting code as per black. ([@theskumar])

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -30,7 +30,7 @@ psycopg2-binary==2.8.2
 Pillow==6.2.0
 django-extensions==2.1.9
 django-uuid-upload-path==1.0.0
-django-versatileimagefield==2.01
+django-versatileimagefield==2.0
 
 # REST APIs
 # -------------------------------------

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -1,12 +1,13 @@
 # Core Stuff
 # -------------------------------------
-Django==2.2.10
+Django==3.0.5
 
 # Configuration
 # -------------------------------------
 argon2-cffi==19.1.0
 django-environ==0.4.5
-django-sites==0.10
+# For Django 3.x
+-e git+git://github.com/CuriousLearner/django-sites@upgrade-django-3.x#egg=django_sites
 python-dotenv==0.10.3
 {%- if cookiecutter.add_django_cors_headers.lower() == 'y' %}
 django-cors-headers==3.1.1
@@ -29,7 +30,7 @@ psycopg2-binary==2.8.2
 Pillow==6.2.0
 django-extensions==2.1.9
 django-uuid-upload-path==1.0.0
-django-versatileimagefield==1.11
+django-versatileimagefield==2.01
 
 # REST APIs
 # -------------------------------------

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -14,7 +14,7 @@ ipdb==0.12
 pytest==4.6.2
 pytest-django==3.5.0
 pytest-cov==2.7.1
-django-dynamic-fixture==2.0.0
+django-dynamic-fixture==3.1.0
 flake8-mypy==17.8.0
 pytest-mock==1.10.4
 

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -6,7 +6,7 @@ isort==4.3.20
 
 # Debugging
 # -------------------------------------
-django-debug-toolbar==1.11
+django-debug-toolbar==2.2
 ipdb==0.12
 
 # Testing and coverage

--- a/{{cookiecutter.github_repository}}/requirements/production.txt
+++ b/{{cookiecutter.github_repository}}/requirements/production.txt
@@ -9,7 +9,7 @@ boto3==1.9.165
 
 # Caching
 # -------------------------------------
-django-redis==4.10.0
+django-redis==4.11.0
 hiredis==1.0.0
 
 {% if cookiecutter.newrelic == 'y' %}

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -7,7 +7,7 @@ import environ
 {%- if cookiecutter.add_django_cors_headers.lower() == 'y' %}
 from corsheaders.defaults import default_headers
 {%- endif %}
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 ROOT_DIR = environ.Path(__file__) - 2  # (/a/b/myfile.py - 2 = /a/)

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -12,10 +12,6 @@ Adds sensible default for running app in production.
 # Standard Library
 from email.utils import getaddresses
 
-# Third Party Stuff
-from django.utils import six
-
-
 from .common import *  # noqa F405
 from .common import (
     DATABASES,
@@ -110,9 +106,8 @@ if ENABLE_MEDIA_UPLOAD_TO_S3:
     # Revert the following and use str after the above-mentioned bug is fixed in
     # either django-storage-redux or boto
     AWS_HEADERS = {
-        "Cache-Control": six.b(
-            "max-age=%d, s-maxage=%d, must-revalidate" % (AWS_EXPIRY, AWS_EXPIRY)
-        )
+        "Cache-Control": "max-age={}, s-maxage={}, must-revalidate".format(
+            AWS_EXPIRY, AWS_EXPIRY
     }
 
     # URL that handles the media served from MEDIA_ROOT, used for managing stored files.

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -108,6 +108,7 @@ if ENABLE_MEDIA_UPLOAD_TO_S3:
     AWS_HEADERS = {
         "Cache-Control": "max-age={}, s-maxage={}, must-revalidate".format(
             AWS_EXPIRY, AWS_EXPIRY
+        )
     }
 
     # URL that handles the media served from MEDIA_ROOT, used for managing stored files.

--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -106,9 +106,7 @@ if ENABLE_MEDIA_UPLOAD_TO_S3:
     # Revert the following and use str after the above-mentioned bug is fixed in
     # either django-storage-redux or boto
     AWS_HEADERS = {
-        "Cache-Control": "max-age={}, s-maxage={}, must-revalidate".format(
-            AWS_EXPIRY, AWS_EXPIRY
-        )
+        "Cache-Control": f"max-age={AWS_EXPIRY}, s-maxage={AWS_EXPIRY}, must-revalidate"
     }
 
     # URL that handles the media served from MEDIA_ROOT, used for managing stored files.

--- a/{{cookiecutter.github_repository}}/settings/testing.py
+++ b/{{cookiecutter.github_repository}}/settings/testing.py
@@ -1,6 +1,7 @@
 # Do this here, so that .env get loaded while running `pytest` from shell
 # Third Party Stuff
 from dotenv import find_dotenv, load_dotenv
+
 load_dotenv(find_dotenv())
 
 from .development import *  # noqa F405

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/exceptions.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/exceptions.py
@@ -1,8 +1,8 @@
 # Third Party Stuff
 from django.core.exceptions import PermissionDenied as DjangoPermissionDenied
 from django.http import Http404
-from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
+from django.utils.encoding import force_str
+from django.utils.translation import gettext_lazy as _
 from rest_framework import exceptions, status
 from rest_framework.response import Response
 
@@ -123,7 +123,7 @@ def format_exception(exc):
         for error_msg in exc.detail:
             detail["errors"].append({"message": error_msg})
     else:
-        detail["errors"].append({"message": force_text(exc.detail)})
+        detail["errors"].append({"message": force_str(exc.detail)})
 
     return detail
 

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/utils.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/utils.py
@@ -3,7 +3,7 @@
 from uuid import UUID
 
 # Third Party Stuff
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 
 
@@ -19,6 +19,6 @@ def decode_uuid_from_base64(uuid_value: str):
     Returns a valid UUID value or None
     """
     try:
-        return UUID(force_text(urlsafe_base64_decode(uuid_value)))
+        return UUID(force_str(urlsafe_base64_decode(uuid_value)))
     except (ValueError, OverflowError, TypeError):
         return None

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/models.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/models.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import (
 from django.contrib.postgres.fields import CIEmailField
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # {{ cookiecutter.project_name }} Stuff
 from {{cookiecutter.main_module}}.base.models import UUIDModel


### PR DESCRIPTION
> Why was this change necessary?

Updates cookiecutter template to support Django 3.x

> How does it address the problem?

Updates the version of various library and for the time being, add a patched version for django-sites.

> Are there any side effects?

None.