### PR TITLE
upgrade whitenoise to work with django 3

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -16,7 +16,7 @@ django-cors-headers==3.1.1
 {% if cookiecutter.enable_whitenoise.lower() == 'y' -%}
 # Staticfiles
 # -------------------------------------
-whitenoise==4.1.2
+whitenoise==5.0.1
 {%- endif %}
 
 # Extensions


### PR DESCRIPTION


> Why was this change necessary?

whitenoise tries to import django.utils.six which does not exist in django3 anymore.

> How does it address the problem?

resolves import error.

> Are there any side effects?

not in my knowledge.
