### PR TITLE
Fix travis config for postgresql 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-dist: xenial
+dist: bionic
 
 python:
   - '3.7'
@@ -7,29 +7,26 @@ python:
 node_js:
   - "10"
 
-cache:
-  pip: true
-  directories:
-  - node_modules # NPM packages
-
-env:
-  global:
-  - PGHOST=localhost
-  - PGUSER=postgres
-  - PGPORT=5433
-
-before_install:
-  - sudo apt-get update
-  - sudo apt-get --yes remove postgresql\*
-  - sudo apt-get install -y postgresql-11 postgresql-client-11
-  - sudo cp /etc/postgresql/{9.6,11}/main/pg_hba.conf
-  - sudo service postgresql restart 11
-
 services:
   - postgresql
 
 addons:
-  postgresql: "11.2"
+  postgresql: "11"
+  apt:
+    packages:
+    - postgresql-11
+    - postgresql-client-11
+    - libgdal-dev
+    - postgresql-11-postgis-2.5
+
+env:
+  global:
+    - DATABASE_URL=postgis://postgres@localhost/postgres
+
+cache:
+  pip: true
+  directories:
+  - node_modules # NPM packages
 
 install:
   - pip install cookiecutter==1.6.0

--- a/{{cookiecutter.github_repository}}/.travis.yml
+++ b/{{cookiecutter.github_repository}}/.travis.yml
@@ -2,22 +2,26 @@
 # see the Travis CI documentation: https://docs.travis-ci.com
 
 language: python
-dist: xenial
+dist: bionic
 
 python:
-  - '3.7.3'
+  - '3.7'
 
 node_js:
-  - "10"
+  - '13'
+
+services:
+  - postgresql
 
 addons:
-  postgresql: "11.2"
-
-{%- if cookiecutter.postgis.lower() == 'y' %}
-addons:
+  postgresql: '11'
   apt:
     packages:
-      - libgdal-dev
+    - postgresql-11
+    - postgresql-client-11
+{%- if cookiecutter.postgis.lower() == 'y' %}
+    - libgdal-dev
+    - postgresql-11-postgis-2.5
 {%- endif %}
 
 cache:
@@ -30,28 +34,11 @@ services:
 
 env:
   global:
-  - PGDATABASE=postgres
-  - PGHOST=localhost
-  - PGUSER=postgres
-  - PGPASS=''
-  - PGPORT=5433
 {%- if cookiecutter.postgis.lower() == 'y' %}
-  - DATABASE_URL=postgis://${PGUSER}:${PGPASS}@${PGHOST}:${PGPORT}/${PGDATABASE}
-  - POSTGRES_IMAGE=mdillon/postgis:11
+  - DATABASE_URL=postgis://postgres@localhost/postgres
 {%- else %}
-  - DATABASE_URL=postgres://${PGUSER}:${PGPASS}@${PGHOST}:${PGPORT}/${PGDATABASE}
-  - POSTGRES_IMAGE=postgres:11
+  - DATABASE_URL=postgres://postgres@localhost/postgres
 {%- endif %}
-
-before_install:
-  - sudo apt-get update
-  - sudo apt-get --yes remove postgresql\*
-  - sudo apt-get install -y postgresql-11 postgresql-client-11
-  - sudo cp /etc/postgresql/{9.6,11}/main/pg_hba.conf
-  - sudo service postgresql restart 11
-
-before_cache:
-  - rm -f $HOME/.cache/pip/log/debug.log
 
 install:
   - pip install -r requirements/development.txt


### PR DESCRIPTION
> Why was this change necessary?

Postgresql 11 is natively supported on bionic dist (Ubuntu 18), this removes the hackish code for setting up postgresql11 on travis.

I also enables postgis setup by default to be checked while running tests in this cookiecutter.

> How does it address the problem?

Update travis.yml to use standard installation config.

> Are there any side effects?

No.
