### PR TITLE
fix(users/serializers): Add first_name and last_name

### DIFF
--- a/{{cookiecutter.github_repository}}/tests/integration/test_auth.py
+++ b/{{cookiecutter.github_repository}}/tests/integration/test_auth.py
@@ -15,11 +15,50 @@ pytestmark = pytest.mark.django_db
 
 def test_user_registration(client):
     url = reverse("auth-register")
+    credentials = {
+        "email": "test@test.com",
+        "password": "localhost",
+        "first_name": "S",
+        "last_name": "K",
+    }
+    response = client.json.post(url, json.dumps(credentials))
+    assert response.status_code == 201
+    expected_keys = ["id", "email", "first_name", "last_name", "auth_token"]
+    assert set(expected_keys).issubset(response.data.keys())
+
+    assert response.data["email"] == "test@test.com"
+    assert response.data["first_name"] == "S"
+    assert response.data["last_name"] == "K"
+
+
+def test_user_registration_without_name(client):
+    url = reverse("auth-register")
     credentials = {"email": "test@test.com", "password": "localhost"}
     response = client.json.post(url, json.dumps(credentials))
     assert response.status_code == 201
     expected_keys = ["id", "email", "first_name", "last_name", "auth_token"]
     assert set(expected_keys).issubset(response.data.keys())
+
+    assert response.data["email"] == "test@test.com"
+    assert response.data["first_name"] == ""
+    assert response.data["last_name"] == ""
+
+
+def test_user_registration_with_blank_name(client):
+    url = reverse("auth-register")
+    credentials = {
+        "email": "test@test.com",
+        "password": "localhost",
+        "first_name": "",
+        "last_name": "",
+    }
+    response = client.json.post(url, json.dumps(credentials))
+    assert response.status_code == 201
+    expected_keys = ["id", "email", "first_name", "last_name", "auth_token"]
+    assert set(expected_keys).issubset(response.data.keys())
+
+    assert response.data["first_name"] == ""
+    assert response.data["last_name"] == ""
 
 
 def test_user_login(client):

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/serializers.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/serializers.py
@@ -22,6 +22,8 @@ class LoginSerializer(serializers.Serializer):
 class RegisterSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True)
     password = serializers.CharField(required=True)
+    first_name = serializers.CharField(required=False, allow_blank=True)
+    last_name = serializers.CharField(required=False, allow_blank=True)
 
     def validate_email(self, value):
         user = user_services.get_user_by_email(email=value)


### PR DESCRIPTION
> Why was this change necessary?

The registration API didn't allow `first_name` and `last_name` to be saved.

> How does it address the problem?

The two fields have been added to the registration serializer.

> Are there any side effects?

None.
