### PR TITLE
docs(): automate generating the latest db schema on deployment in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.x]
 
+- Add database schema generation in docs on deployment ([@jainmickey])
 - Remove support for webpack ([@theskumar])
 - Use `Makefile` in the place of `fabric` ([@theskumar])
 - Add support for Django 3.x ([@CuriousLearner]).

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -26,7 +26,7 @@ else
 fi
 
 if echo "{{ cookiecutter.enable_heroku_deployment }}" | grep -iq "^n"; then
-    rm -rf uwsgi.ini Procfile runtime.txt bin
+    rm -rf uwsgi.ini Procfile runtime.txt bin/post_compile
 fi
 
 if echo "{{ cookiecutter.add_ansible }}" | grep -iq "^n"; then

--- a/{{cookiecutter.github_repository}}/.gitignore
+++ b/{{cookiecutter.github_repository}}/.gitignore
@@ -84,6 +84,9 @@ _docs_html/
 media/
 provisioner/site.retry
 
+# DB Schema as it gets generated on server
+database-schema.svg
+
 # Virtualenv
 venv/
 

--- a/{{cookiecutter.github_repository}}/bin/generate_db_schema.py
+++ b/{{cookiecutter.github_repository}}/bin/generate_db_schema.py
@@ -1,0 +1,8 @@
+# Standard Library
+import os
+from os.path import dirname, abspath
+
+parent_dir = dirname(dirname(abspath(__file__)))
+os.system(f"python {parent_dir}/manage.py graph_models -a > db.dot  && dot -Tsvg db.dot -o db.svg")
+os.system(f"mv db.svg {parent_dir}/docs/backend/database-schema.svg")
+os.system("rm db.dot")

--- a/{{cookiecutter.github_repository}}/docs/index.md
+++ b/{{cookiecutter.github_repository}}/docs/index.md
@@ -9,5 +9,6 @@ __Version:__ {{ cookiecutter.version }}
 - JIRA Board
 - [API Playground](/api-plaground)
 - [Django Admin](/admin)
+- [Database Schema](backend/database-schema.svg)
 
 {!releases.md!}

--- a/{{cookiecutter.github_repository}}/mkdocs.yml
+++ b/{{cookiecutter.github_repository}}/mkdocs.yml
@@ -14,6 +14,7 @@ nav:
 - Technical Specs:
   - Server Config: backend/server_config.md
   - Coding Rules: backend/coding_rules.md
+  - Database Schema: backend/database-schema.svg
 - Releases:
   - Changelog: releases.md
 

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
@@ -55,7 +55,17 @@
   notify: reload celery  # reload celery everytime uwsgi conf changes
   {%- endif %}
 
-{% raw %}- name: Build documentation for "/docs" url.
+{% raw %}- name: apt_get install graphviz for db schema generation
+  apt: pkg=graphviz state=present
+
+- name: Generate DB Schema.
+  command: "{{ venv_path }}/bin/python bin/generate_db_schema.py"
+  args:
+    chdir: "{{ project_path }}"
+  become: false
+  tags: ['deploy', 'documentation']
+
+- name: Build documentation for "/docs" url.
   command: "{{ venv_path }}/bin/mkdocs build"
   args:
     chdir: "{{ project_path }}"

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/main.yml
@@ -59,9 +59,10 @@
   apt: pkg=graphviz state=present
 
 - name: Generate DB Schema.
-  command: "{{ venv_path }}/bin/python bin/generate_db_schema.py"
+  shell: "source {{ venv_path }}/bin/activate && python bin/generate_db_schema.py"
   args:
     chdir: "{{ project_path }}"
+    executable: /bin/bash
   become: false
   tags: ['deploy', 'documentation']
 

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -59,4 +59,9 @@ celery[redis]==4.4.2
 PyJWT==1.7.1
 django-mail-templated==2.6.5
 
+# Generating DB Schema
+# --------------------------------------
+pydot==1.4.1
+pyparsing==2.4.6
+
 -r docs.txt

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = (
     "raven.contrib.django.raven_compat",
 {%- endif %}
     "mail_templated",  # https://github.com/artemrizhov/django-mail-templated
+    "django_extensions",  # http://django-extensions.readthedocs.org/
 )
 
 # INSTALLED APPS CONFIGURATION

--- a/{{cookiecutter.github_repository}}/settings/development.py
+++ b/{{cookiecutter.github_repository}}/settings/development.py
@@ -64,10 +64,6 @@ CACHES = {
     }
 }
 
-# django-extensions (http://django-extensions.readthedocs.org/)
-# ------------------------------------------------------------------------------
-INSTALLED_APPS += ("django_extensions",)
-
 # django-debug-toolbar
 # ------------------------------------------------------------------------------
 MIDDLEWARE += ["debug_toolbar.middleware.DebugToolbarMiddleware"]  # noqa: F405


### PR DESCRIPTION
> Why was this change necessary?

It gives management & other team members better idea about current database schema

> How does it address the problem?

Gives everyone access of latest db schema

> Are there any side effects?

No
