### PR TITLE
Fix formatting for failed validation for one of the items in ListField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [3.x]
 
+- Fixed exception formatter for validation error in the child of ListField. ([@theskumar])
 - Renamed setting `CORS_ORIGIN_WHITELIST` to`CORS_ALLOWED_ORIGINS`. ([@theskumar])
 
 ## [2.x]


### PR DESCRIPTION
The current exception formatter doesn't support displaying errors if the error
happened while validating any one of the child items in a ListField.

Currently for input:

```
{
    "items": ["", ""]
}
```

The response is:

```
{
    "error_type": "ValidationError",
    "errors": [
        {
            "field": "items",
            "message": 0
        },
        {
            "field": "items",
            "message": 1
        }
}
```

After this fix, the output becomes:
```
{
    "error_type": "ValidationError",
    "errors": [
        {
            "field": "items",
            "message": "Validation failed for one of the item in the list",
            "errors": [
                {
                    "field": 0,
                    "messsage": "This list may not be blank"
                },
                {
                    "field": 1,
                    "messsage": "This list may not be blank"
                }
            ]
        }
}
```

