### PR TITLE
PyTest: Run failed test and then new test cases first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [3.x]
 
+- PyTest: Run failed test and then new test cases first ([@theskumar])
 - Renamed setting `CORS_ORIGIN_WHITELIST` to`CORS_ALLOWED_ORIGINS`. ([@theskumar])
 
 ## [2.x]

--- a/{{cookiecutter.github_repository}}/setup.cfg
+++ b/{{cookiecutter.github_repository}}/setup.cfg
@@ -18,6 +18,7 @@ select = B,C,E,F,W,T4,B9
 exclude = .tox,.git,*/migrations/*,*/static/*,docs,venv,.venv,node_modules
 
 [tool:pytest]
+addopts = --failed-first --new-first
 DJANGO_SETTINGS_MODULE = settings.testing
 norecursedirs = .tox .git */migrations/* */static/* docs venv node_modules
 


### PR DESCRIPTION
 Add default parameter to pytest while running test via cli so that the last failed
 test are run first and then all the recently modified test are run in cronological
 order.

> Why was this change necessary?

This saves time running test as the failed test are run first or the recently modified. The failure is caught early, as the successful test or old tests are run later at the end.

> How does it address the problem?

Adds default argurements `--failed-first / --ff` and `--new-first / --nf`  to PyTest.

> Are there any side effects?

Not that I can think of. It changes the order of test execution. Currently the test are run as they are discovered on the disk, most likely alphabetically. 
