### PR TITLE
Fix the startup for celery and uwsgi-emperor on Ubuntu 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,16 @@
 # ChangeLog
 All notable changes to this project will be documented in this file.
 
-## [3.x]
+# [3.x]
 
+## Nov 3, 2020
+
+- Fix ansible startup for celery and uwsgi ([@theskumar])
 - Fixed exception formatter for validation error in the child of ListField. ([@theskumar])
 - PyTest: Run failed test and then new test cases first ([@theskumar])
 - Renamed setting `CORS_ORIGIN_WHITELIST` to`CORS_ALLOWED_ORIGINS`. ([@theskumar])
 
-## [2.x]
+# [2.x]
 
 - Add database schema generation in docs on deployment ([@jainmickey])
 - Remove support for webpack ([@theskumar])

--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/tasks/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/tasks/main.yml
@@ -26,12 +26,4 @@
 - name: copy celery beat service
   template: src=celerybeat.service.j2 dest=/etc/systemd/system/celerybeat-{{ project_namespace }}.service
   tags: ['celery']
-
-- name: ensure celery worker is running
-  systemd: state=restarted daemon_reload=yes enabled=yes name=celery-{{ project_namespace }}
-  tags: ['celery', 'deploy']
-
-- name: ensure celerybeat worker is running
-  systemd: state=started daemon_reload=yes enabled=yes name=celerybeat-{{ project_namespace }}
-  tags: ['celery', 'deploy']
 {% endraw %}

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/defaults/main.yml
@@ -15,6 +15,7 @@ uwsgi_timeout: 30
 uwsgi_keepalive: 2
 uwsgi_loglevel: info
 uwsgi_conf_path: /etc/uwsgi-emperor/vassals
+uwsgi_emperor_pid_file: /run/uwsgi-emperor.pid
 uwsgi_socket: "/tmp/uwsgi-{{ project_namespace }}.sock"
 uwsgi_pid_file: "/tmp/uwsgi-{{ project_namespace }}.pid"
 

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/uwsgi-setup.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/uwsgi-setup.yml
@@ -31,6 +31,11 @@
   file: path={{ uwsgi_log_dir }} state=directory owner={{uwsgi_user}} group={{uwsgi_group}} mode=751 recurse=yes
   tags: ['configure']
 
+- name: ensure uwsgi emperor pid file as correct permissions
+  file:
+    path: '{{ uwsgi_emperor_pid_file }}'
+    mode: '0644'
+
 - name: ensure django app config is added as uwsgi vassal
   template: src=django.uwsgi.ini.j2
             dest={{ uwsgi_conf_path }}/{{project_namespace }}.ini

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/uwsgi-setup.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/tasks/uwsgi-setup.yml
@@ -31,6 +31,12 @@
   file: path={{ uwsgi_log_dir }} state=directory owner={{uwsgi_user}} group={{uwsgi_group}} mode=751 recurse=yes
   tags: ['configure']
 
+- name: update uwsgi-emperor init file
+  template: src=uwsgi-emperor-init.d.j2
+            dest=/etc/init.d/uwsgi-emperor
+            mode=755
+  register: uwsgiconf
+
 - name: ensure uwsgi emperor pid file as correct permissions
   file:
     path: '{{ uwsgi_emperor_pid_file }}'

--- a/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/uwsgi-emperor-init.d.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/project_data/templates/uwsgi-emperor-init.d.j2
@@ -1,0 +1,32 @@
+{% raw %}#!/bin/sh
+# kFreeBSD do not accept scripts as interpreters, using #!/bin/sh and sourcing.
+if [ true != "$INIT_D_SCRIPT_SOURCED" ]; then
+    set "$0" "$@"
+    INIT_D_SCRIPT_SOURCED=true . /lib/init/init-d-script
+fi
+### BEGIN INIT INFO
+# Provides:          uwsgi-emperor
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs $network
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start/stop uWSGI server instance(s)
+# Description:       This script manages uWSGI Emperor server instance(s).
+### END INIT INFO
+
+# Author: Jonas Smedegaard <dr@jones.dk>
+
+DESC="uWSGI Emperor server"
+DAEMON=/usr/bin/uwsgi
+PIDFILE={{ uwsgi_emperor_pid_file }}
+LOGFILE=/var/log/uwsgi/emperor.log
+# TODO: drop die-on-term with 2.1+ (see bug#799971)
+DAEMON_ARGS="--ini /etc/uwsgi-emperor/emperor.ini --die-on-term --pidfile $PIDFILE --daemonize $LOGFILE"
+SCRIPTNAME="/etc/init.d/uwsgi-emperor"
+
+alias do_reload=do_reload_sigusr1
+
+do_start_prepare() {
+    # Create with correct permissions in advance as uwsgi with --daemonize creates it world write otherwise
+    touch "$PIDFILE"
+}{% endraw %}


### PR DESCRIPTION
- The systemd refuses to start/stop uwsgi fails to start when the PID file world writeable,
  the solution is to update the uwsgi init script to resuse the pid file which is created with
  correct permssions instead of letting uwsgi-emperor create a world-writable pid file. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=934731
- Celery services are already registered with systemd do when we invoke the ansible startup tasks
  they fail, so those tasks are removed.