### PR TITLE
docs - add documentation for MultipleSerializerMixin

### DIFF
--- a/{{cookiecutter.github_repository}}/docs/backend/api_mixins.md
+++ b/{{cookiecutter.github_repository}}/docs/backend/api_mixins.md
@@ -21,3 +21,23 @@ class FooViewSet(PermissionPerAction, viewsets.ModelViewSet):
     }
 ```
 
+## Multiple Serializers for a viewset
+
+Similiar to permission classes, DRF allows us to only set one serializer per viewset. 
+
+```
+class FooViewSet(viewsets.ModelViewSet):
+    serializer_class = serializers.FooSerializer
+```
+
+`MultipleSerializerMixin` available in the `base` module allows us to set different serializer classes for each of the actions (`list`, `retrieve`, `create`, `partial_update`, `update` or any other custom actions) on the viewset.
+
+```
+import project_name.base.api.mixins import PermissionPerAction
+
+class FooViewSet(PermissionPerAction, viewsets.ModelViewSet):
+    serializer_classes = {
+        "create": serializers.CreateFooSerializer,
+        "list": serializers.ReadFooSerializer
+    }
+```

--- a/{{cookiecutter.github_repository}}/docs/backend/api_mixins.md
+++ b/{{cookiecutter.github_repository}}/docs/backend/api_mixins.md
@@ -33,9 +33,9 @@ class FooViewSet(viewsets.ModelViewSet):
 `MultipleSerializerMixin` available in the `base` module allows us to set different serializer classes for each of the actions (`list`, `retrieve`, `create`, `partial_update`, `update` or any other custom actions) on the viewset.
 
 ```
-import project_name.base.api.mixins import PermissionPerAction
+import project_name.base.api.mixins import MultipleSerializerMixin
 
-class FooViewSet(PermissionPerAction, viewsets.ModelViewSet):
+class FooViewSet(MultipleSerializerMixin, viewsets.ModelViewSet):
     serializer_classes = {
         "create": serializers.CreateFooSerializer,
         "list": serializers.ReadFooSerializer


### PR DESCRIPTION
> Why was this change necessary?

Adds separate doc section for multiple serializer mixin in our documentation on api mixins.

> How does it address the problem?


> Are there any side effects?

No
