### PR TITLE
fix(users/auth): Add validation for name & password in registration

### DIFF
--- a/{{cookiecutter.github_repository}}/tests/integration/test_auth.py
+++ b/{{cookiecutter.github_repository}}/tests/integration/test_auth.py
@@ -61,6 +61,35 @@ def test_user_registration_with_blank_name(client):
     assert response.data["last_name"] == ""
 
 
+def test_user_registration_with_long_first_and_last_name(client):
+    url = reverse("auth-register")
+    credentials = {
+        "email": "test@test.com",
+        "password": "localhost",
+        "first_name": "S" * 121,
+        "last_name": "K" * 121,
+    }
+    response = client.json.post(url, json.dumps(credentials))
+    assert response.status_code == 400
+    assert response.data["errors"][0]["field"] == "first_name"
+    assert response.data["errors"][0]["message"] == "Ensure this field has no more than 120 characters."
+    assert response.data["errors"][1]["field"] == "last_name"
+    assert response.data["errors"][1]["message"] == "Ensure this field has no more than 120 characters."
+
+
+def test_validate_password_during_registration(client):
+    url = reverse("auth-register")
+    credentials = {
+        "email": "test@test.com",
+        "password": "123456789",
+        "first_name": "S",
+        "last_name": "K",
+    }
+    response = client.json.post(url, json.dumps(credentials))
+    assert response.status_code == 400
+    assert response.data["errors"][0]["field"] == "password"
+    assert response.data["errors"][0]["message"] == "This password is too common."
+
 def test_user_login(client):
     url = reverse("auth-login")
     u = f.create_user(email="test@example.com", password="test")

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/serializers.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/serializers.py
@@ -22,8 +22,12 @@ class LoginSerializer(serializers.Serializer):
 class RegisterSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True)
     password = serializers.CharField(required=True)
-    first_name = serializers.CharField(required=False, allow_blank=True)
-    last_name = serializers.CharField(required=False, allow_blank=True)
+    first_name = serializers.CharField(required=False, allow_blank=True, max_length=120)
+    last_name = serializers.CharField(required=False, allow_blank=True, max_length=120)
+
+    def validate_password(self, value):
+        password_validation.validate_password(value)
+        return value
 
     def validate_email(self, value):
         user = user_services.get_user_by_email(email=value)


### PR DESCRIPTION
> Why was this change necessary?

There was no validation present during registration for `password` field. If the `first_name` or `last_name` will be more than 120 characters, instead of raising error, 500 server error will appear.

> How does it address the problem?

It adds `max_length` validation in `first_name` and `last_name` for registration serializer and makes sure to run password validations.

> Are there any side effects?

None.
