### PR TITLE
chore(): Add Github action CI on projects PR

### DIFF
--- a/{{cookiecutter.github_repository}}/.github/workflows/main.yml
+++ b/{{cookiecutter.github_repository}}/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Run tests for {{cookiecutter.main_module}}
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
> Why was this change necessary?

Github Action CI won't trigger on PR for projects

> How does it address the problem?

Make CI trigger in project PRs.

> Are there any side effects?

None.
