### PR TITLE
upgrade(requirements): Celery 4.4.7 -> 5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 # [3.x]
 
+## Mar 1, 2020
+
+- Upgrade Celery to 5.0.2. ([@CuriousLearner])
+
 ## Dec 15, 2020
 
 - Upgrade to Python 3.9. ([@CuriousLearner])

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -51,7 +51,7 @@ raven==6.10.0
 
 # Async Tasks
 # -------------------------------------
-celery[redis]==4.4.7
+celery[redis]==5.0.2
 {%- endif %}
 
 # Auth Stuff


### PR DESCRIPTION
> Why was this change necessary?

Celery 4.4.7 had a regression introduced where with `--detach` and `--logfile`, it tries to find amqp although being explicitly instructed to connect with redis. More information here: https://github.com/celery/celery/issues/6370

> How does it address the problem?

It upgrades celery to 5.0.2 which no longer has this issue.

> Are there any side effects?

None that I'm aware of.
