### PR TITLE
fix(provisioner): celery beat start command for systemd service

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/celery/templates/celerybeat.service.j2
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/celery/templates/celerybeat.service.j2
@@ -9,7 +9,7 @@ RuntimeDirectory={{ celery_runtime_dir }}
 Group={{ celery_group }}
 Restart=always
 WorkingDirectory={{ project_path }}
-ExecStart={{ venv_path }}/bin/celery beat -A {{ project_name }}  -l {{ celery_log_level }} \
+ExecStart={{ venv_path }}/bin/celery -A {{ project_name }} beat -l {{ celery_log_level }} \
     --logfile={{ celerybeat_log_file }} --pidfile={{ celerybeat_pid_file }}  --schedule={{ celerybeat_schedule_file}}
 
 [Install]


### PR DESCRIPTION
> Why was this change necessary?

the upgrade to celery 5 renders the previous command incompatible

> How does it address the problem?

uses the correct command invocation

> Are there any side effects?


