### PR TITLE
feat() - make limit offset pagination default and add cursor pagination as optional

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -20,4 +20,5 @@
     , "add_celery": "n"
     , "add_django_cors_headers": "y"
     , "add_pre_commit": "y"
+    , "use_cursor_pagination": "n"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -20,5 +20,5 @@
     , "add_celery": "n"
     , "add_django_cors_headers": "y"
     , "add_pre_commit": "y"
-    , "use_cursor_pagination": "n"
+    , "pagination": ["LimitOffsetPagination", "CursorPagination"]
 }

--- a/{{cookiecutter.github_repository}}/docs/api/0-overview.md
+++ b/{{cookiecutter.github_repository}}/docs/api/0-overview.md
@@ -52,10 +52,19 @@ PUT     | Used for replacing resources or collections. For PUT requests with no 
 DELETE  | Used for deleting resources.
 
 ## Pagination
+{%- if cookiecutter.use_cursor_pagination.lower() == 'y' %}
 
-Requests that return multiple items will be paginated to 30 items by default. You can specify further pages with the `?page` parameter. For some resources, you can also set a custom page size up to 1000 with the `?per_page` parameter.
+Requests that return multiple items will be paginated to 30 items by default. You can specify cursor for the item with the `?cursor` parameter. For some resources, you can also set a custom page size up to 1000 with the `?per_page` parameter.
 
-Note that page numbering is 1-based and that omitting the `?page` parameter will return the first page.
+Note that offset is 1-based and that omitting the `?cursor` parameter will return results from offset 1.
+
+By Default, the results are ordered in descending order of creation time based on field `-created_at` and it does not return `count` as part of the response.
+{%- else %}
+
+Requests that return multiple items will be paginated to 30 items by default. You can specify offset for the item with the `?offset` parameter. For some resources, you can also set a custom page size up to 1000 with the `?per_page` parameter.
+
+Note that offset is 1-based and that omitting the `?offset` parameter will return results from offset 1.
+{%- endif %}
 
 ## Rate Limit
 

--- a/{{cookiecutter.github_repository}}/docs/api/0-overview.md
+++ b/{{cookiecutter.github_repository}}/docs/api/0-overview.md
@@ -52,14 +52,14 @@ PUT     | Used for replacing resources or collections. For PUT requests with no 
 DELETE  | Used for deleting resources.
 
 ## Pagination
-{%- if cookiecutter.use_cursor_pagination.lower() == 'y' %}
+{%- if cookiecutter.pagination == 'CursorPagination' %}
 
 Requests that return multiple items will be paginated to 30 items by default. You can specify cursor for the item with the `?cursor` parameter. For some resources, you can also set a custom page size up to 1000 with the `?per_page` parameter.
 
 Note that offset is 1-based and that omitting the `?cursor` parameter will return results from offset 1.
 
 By Default, the results are ordered in descending order of creation time based on field `-created_at` and it does not return `count` as part of the response.
-{%- else %}
+{%- elif cookiecutter.pagination == 'LimitOffsetPagination' %}
 
 Requests that return multiple items will be paginated to 30 items by default. You can specify offset for the item with the `?offset` parameter. For some resources, you can also set a custom page size up to 1000 with the `?per_page` parameter.
 

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -82,10 +82,8 @@ REST_FRAMEWORK = {
 {%- if cookiecutter.pagination == 'CursorPagination' %}
     # Cursor Pagination require ordering on field `-created_at`. Make sure that field is part of each model
     # Cursor Pagination does not returns the `count` as part of the response
-    "DEFAULT_PAGINATION_CLASS": "{{ cookiecutter.main_module }}.base.api.pagination.CursorPagination",
-{%- elif cookiecutter.pagination == 'LimitOffsetPagination' %}
-    "DEFAULT_PAGINATION_CLASS": "{{ cookiecutter.main_module }}.base.api.pagination.LimitOffsetPagination",
 {%- endif %}
+    "DEFAULT_PAGINATION_CLASS": "{{ cookiecutter.main_module }}.base.api.pagination.{{ cookiecutter.pagination }}",
     "PAGE_SIZE": 30,
 
     # Default renderer classes for Rest framework

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -79,7 +79,13 @@ API_DEBUG = env.bool("API_DEBUG", default=False)
 # rest_framework
 # ------------------------------------------------------------------------------
 REST_FRAMEWORK = {
-    "DEFAULT_PAGINATION_CLASS": "{{ cookiecutter.main_module }}.base.api.pagination.PageNumberPagination",
+{%- if cookiecutter.use_cursor_pagination.lower() == 'y' %}
+    # Cursor Pagination require ordering on field `-created_at`. Make sure that field is part of each model
+    # Cursor Pagination does not returns the `count` as part of the response
+    "DEFAULT_PAGINATION_CLASS": "{{ cookiecutter.main_module }}.base.api.pagination.CursorPagination",
+{%- else %}
+    "DEFAULT_PAGINATION_CLASS": "{{ cookiecutter.main_module }}.base.api.pagination.LimitOffsetPagination",
+{%- endif %}
     "PAGE_SIZE": 30,
 
     # Default renderer classes for Rest framework

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -79,11 +79,11 @@ API_DEBUG = env.bool("API_DEBUG", default=False)
 # rest_framework
 # ------------------------------------------------------------------------------
 REST_FRAMEWORK = {
-{%- if cookiecutter.use_cursor_pagination.lower() == 'y' %}
+{%- if cookiecutter.pagination == 'CursorPagination' %}
     # Cursor Pagination require ordering on field `-created_at`. Make sure that field is part of each model
     # Cursor Pagination does not returns the `count` as part of the response
     "DEFAULT_PAGINATION_CLASS": "{{ cookiecutter.main_module }}.base.api.pagination.CursorPagination",
-{%- else %}
+{%- elif cookiecutter.pagination == 'LimitOffsetPagination' %}
     "DEFAULT_PAGINATION_CLASS": "{{ cookiecutter.main_module }}.base.api.pagination.LimitOffsetPagination",
 {%- endif %}
     "PAGE_SIZE": 30,

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/api/pagination.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/api/pagination.py
@@ -47,6 +47,8 @@ class CursorPagination(DrfCursorPagination):
     The cursor pagination implementation is necessarily complex.
     For an overview of the position/offset style we use, see this post:
     https://cra.mr/2011/03/08/building-cursors-for-the-disqus-api
+
+    Cursor Pagination does not returns the `count` as part of the response
     """
 
     # Ordering field used for cursor pagination

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/api/pagination.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/base/api/pagination.py
@@ -1,22 +1,25 @@
 # Third Party Stuff
-from rest_framework.pagination import PageNumberPagination as DrfPageNumberPagination
+from rest_framework.pagination import (
+    LimitOffsetPagination as DrfLimitOffsetPagination,
+    CursorPagination as DrfCursorPagination,
+)
 
 
-class PageNumberPagination(DrfPageNumberPagination):
+class LimitOffsetPagination(DrfLimitOffsetPagination):
 
-    # Client can control the page using this query parameter.
-    page_query_param = "page"
+    # Client can control the offset using this query parameter.
+    offset_query_param = 'offset'
 
     # Client can control the page size using this query parameter.
     # Default is 'None'. Set to eg 'page_size' to enable usage.
-    page_size_query_param = "per_page"
+    limit_query_param = 'per_page'
 
     # Set to an integer to limit the maximum page size the client may request.
     # Only relevant if 'page_size_query_param' has also been set.
-    max_page_size = 1000
+    max_limit = 1000
 
 
-def paginated_response(request, queryset, serializer_class, extra_context=None):
+def limit_offset_paginated_response(request, queryset, serializer_class, extra_context=None):
     """Utlity function to return a paginated response.
 
     Returns `Response` object with pagination info after serializing the django
@@ -26,7 +29,59 @@ def paginated_response(request, queryset, serializer_class, extra_context=None):
     If `extra_context`(dict) is provided, it will be passed to the serializer_class
     as context variables.
     """
-    paginator = PageNumberPagination()
+    paginator = LimitOffsetPagination()
+    paginated_queryset = paginator.paginate_queryset(queryset=queryset, request=request)
+    serializer_context = {"request": request}
+
+    if extra_context:
+        serializer_context.update(extra_context)
+
+    serializer = serializer_class(
+        paginated_queryset, context=serializer_context, many=True
+    )
+    return paginator.get_paginated_response(data=serializer.data)
+
+
+class CursorPagination(DrfCursorPagination):
+    """
+    The cursor pagination implementation is necessarily complex.
+    For an overview of the position/offset style we use, see this post:
+    https://cra.mr/2011/03/08/building-cursors-for-the-disqus-api
+    """
+
+    # Ordering field used for cursor pagination
+    # While using cursor pagination, ensure ordering field is part of that model
+    ordering = '-created_at'
+
+    # Client can control the cursor using this query parameter.
+    cursor_query_param = 'cursor'
+
+    # Client can control the page size using this query parameter.
+    # Default is 'None'. Set to eg 'page_size' to enable usage.
+    page_size_query_param = 'per_page'
+
+    # Set to an integer to limit the maximum page size the client may request.
+    # Only relevant if 'page_size_query_param' has also been set.
+    max_page_size = None
+
+    # The offset in the cursor is used in situations where we have a
+    # nearly-unique index. (Eg millisecond precision creation timestamps)
+    # We guard against malicious users attempting to cause expensive database
+    # queries, by having a hard cap on the maximum possible size of the offset.
+    offset_cutoff = 1000
+
+
+def cursor_paginated_response(request, queryset, serializer_class, extra_context=None):
+    """Utlity function to return a paginated response.
+
+    Returns `Response` object with pagination info after serializing the django
+    `queryset` as per the `serializer_class` given and processing the current
+    `page` from the `request` object.
+
+    If `extra_context`(dict) is provided, it will be passed to the serializer_class
+    as context variables.
+    """
+    paginator = CursorPagination()
     paginated_queryset = paginator.paginate_queryset(queryset=queryset, request=request)
     serializer_context = {"request": request}
 


### PR DESCRIPTION
> Why was this change necessary?

Page number pagination creates issues on any customization

> How does it address the problem?

Cursor Pagination requires ordering on `timestamp` field which restricts its use everywhere. This change will add `Limit Offset` pagination as default and ask for `Cursor Pagination` on project generation.

> Are there any side effects?

No
