### PR TITLE
fix(installation): Upgrade pip before installing requirements

### DIFF
--- a/{{cookiecutter.github_repository}}/Makefile
+++ b/{{cookiecutter.github_repository}}/Makefile
@@ -22,6 +22,7 @@ regenerate:  ## Delete and create new database.
 .PHONY: regenerate
 
 install: venv  ## Install and setup project dependencies
+	${PYTHON_PATH}python -m pip install --upgrade pip wheel
 	${PYTHON_PATH}python -m pip install -r requirements/development.txt
 	${PYTHON_PATH}pre-commit install
 ifneq ($(CI),True)


### PR DESCRIPTION
> Why was this change necessary?

* Upgrading pip

  Pip version used in virtualenv is associated with
  python version, and older python versions end up using outdated pip that
  came packaged with it.

  This results in a failure when installing some packages like
  `cryptography`

* Installing wheel: Updated standard for python packaging.

  Without wheel a few packages have to fallback on `setup.py`, throwing
  this message:

  > Using legacy 'setup.py install' for pkg-name, since package 'wheel' is not installed.

  Wheel is also safer than setup.py and faster
  Source: https://www.python.org/dev/peps/pep-0427/#rationale

> How does it address the problem?

Upgrades pip and installs wheel before any installation begins when doing `make install`

> Are there any side effects?

None
