### PR TITLE
fix(users/auth): pyjwt requires the algorithm when calling decode()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@ All notable changes to this project will be documented in this file.
 
 # [3.x]
 
-## Mar 1, 2020
+## 19 May, 2021
+
+- Fix: pyjwt now needs the algorithm to be specified when calling decode(). ([@tucosaurus])
+
+## Mar 1, 2021
 
 - Upgrade Celery to 5.0.2. ([@CuriousLearner])
 

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/tokens.py
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/users/auth/tokens.py
@@ -10,11 +10,14 @@ from {{cookiecutter.main_module}}.base import exceptions as exc
 from .utils import decode_uuid_from_base64, encode_uuid_to_base64
 
 
+HS256_ALGORITHM = "HS256"
+
+
 def get_token_for_user(user, scope: str) -> str:
     """Generate a new signed token containing a specified user limited for a scope (identified as a string).
     """
     data = {"user_%s_id" % (scope): str(user.id)}
-    return jwt.encode(data, settings.SECRET_KEY)
+    return jwt.encode(data, settings.SECRET_KEY, algorithm=HS256_ALGORITHM)
 
 
 def get_user_for_token(token: str, scope: str):
@@ -29,7 +32,7 @@ def get_user_for_token(token: str, scope: str):
     in the incoming token.
     """
     try:
-        data = jwt.decode(token, settings.SECRET_KEY)
+        data = jwt.decode(token, settings.SECRET_KEY, algorithms=[HS256_ALGORITHM])
     except jwt.DecodeError:
         raise exc.NotAuthenticated("Invalid token")
 


### PR DESCRIPTION
> Why was this change necessary?

https://github.com/jpadilla/pyjwt/blob/master/CHANGELOG.rst#dropped-deprecated-verify-param-in-jwtdecode

> How does it address the problem?

Makes the algorithm explicit while encoding and decoding the token

> Are there any side effects?

No.
