### PR TITLE
Upgrade python dependencies to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes to this project will be documented in this file.
 
 # [3.x]
 
+## 9 Aug, 2021
+
+- Django updated to 3.1.x from 3.2.4 [changelog](https://docs.djangoproject.com/en/3.2/releases/3.2/)
+- python-dotenv updated to 0.19.0 from 0.17.1 [changelog](https://github.com/theskumar/python-dotenv/blob/master/CHANGELOG.md)
+- whitenoise updated to 5.3.0 from 5.2.0 [changelog](http://whitenoise.evans.io/en/stable/changelog.html)
+- psycopg2-binary updated to 2.9.1 from 2.8.6 [changelog](https://www.psycopg.org/docs/news.html#what-s-new-in-psycopg-2-9)
+- Pillow updated to 8.3.1 from 8.2.0 [changelog](https://pillow.readthedocs.io/en/stable/releasenotes/8.3.1.html)
+- django-versatileimagefield updated to 2.1 from 2.0
+- celery updated to 5.1.2 from 5.1.0
+- mkdocs-material updated to 7.2.2 from 7.1.8
+- iSort update to 5.9.3 [changelog](https://github.com/pycqa/isort/blob/main/CHANGELOG.md)
+- pre-commit update to 2.14.0 [changelog](https://github.com/pre-commit/pre-commit/releases)
+- boto3 updated to 1.18.18 from 1.17.94
+- django-redis updated to 5.0.0 from 4.12.1 [changelog](https://pyup.io/changelogs/django-redis/#5.0.0)
+- newrelic updated to 6.8.0.163 from 6.4.1.158
+
 ## 19 May, 2021
 
 - Fix: pyjwt now needs the algorithm to be specified when calling decode(). ([@tucosaurus])

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -1,6 +1,6 @@
 # Core Stuff
 # -------------------------------------
-Django==3.1.8
+Django==3.2.6
 
 # Configuration
 # -------------------------------------
@@ -8,7 +8,7 @@ argon2-cffi==20.1.0
 django-environ==0.4.5
 # For Django 3.x
 -e git+git://github.com/CuriousLearner/django-sites@upgrade-django-3.x#egg=django_sites
-python-dotenv==0.17.0
+python-dotenv==0.19.0
 {%- if cookiecutter.add_django_cors_headers.lower() == 'y' %}
 django-cors-headers==3.7.0
 {%- endif %}
@@ -16,7 +16,7 @@ django-cors-headers==3.7.0
 {% if cookiecutter.enable_whitenoise.lower() == 'y' -%}
 # Staticfiles
 # -------------------------------------
-whitenoise==5.2.0
+whitenoise==5.3.0
 {%- endif %}
 
 # Extensions
@@ -25,12 +25,12 @@ pytz==2021.1
 
 # Models
 # -------------------------------------
-psycopg2-binary==2.8.6
+psycopg2-binary==2.9.1
 
-Pillow==8.2.0
+Pillow==8.3.1
 django-extensions==3.1.3
 django-uuid-upload-path==1.0.0
-django-versatileimagefield==2.0
+django-versatileimagefield==2.1
 
 # REST APIs
 # -------------------------------------
@@ -51,12 +51,12 @@ raven==6.10.0
 
 # Async Tasks
 # -------------------------------------
-celery[redis]==5.0.5
+celery[redis]==5.1.2
 {%- endif %}
 
 # Auth Stuff
 # -------------------------------------
-PyJWT==2.0.1
+PyJWT==2.1.0
 django-mail-templated==2.6.5
 
 # Generating DB Schema

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -2,22 +2,22 @@
 
 # Documentation
 # -------------------------------------
-isort==5.8.0
-black==20.8b1
+isort==5.9.3
+black==21.7b0
 
 # Debugging
 # -------------------------------------
 django-debug-toolbar==3.2.1
-ipdb==0.13.7
+ipdb==0.13.9
 
 # Testing and coverage
 # -------------------------------------
-pytest==6.2.3
-pytest-django==4.2.0
-pytest-cov==2.11.1
+pytest==6.2.4
+pytest-django==4.4.0
+pytest-cov==2.12.1
 django-dynamic-fixture==3.1.1
 flake8-mypy==17.8.0
-pytest-mock==3.5.1
+pytest-mock==3.6.1
 
 # Versioning
 # -------------------------------------
@@ -31,5 +31,5 @@ ansible==2.9.20
 {%- if cookiecutter.add_pre_commit.lower() == 'y' %}
 # Code quality
 #--------------------------------------
-pre-commit==2.12.1
+pre-commit==2.14.0
 {%- endif %}

--- a/{{cookiecutter.github_repository}}/requirements/docs.txt
+++ b/{{cookiecutter.github_repository}}/requirements/docs.txt
@@ -1,5 +1,5 @@
 # Documentation
 # -------------------------------------
-mkdocs-material==7.1.2
+mkdocs-material==7.2.3
 markdown-include==0.6.0
-mkdocs-git-revision-date-localized-plugin==0.9
+mkdocs-git-revision-date-localized-plugin==0.9.2

--- a/{{cookiecutter.github_repository}}/requirements/production.txt
+++ b/{{cookiecutter.github_repository}}/requirements/production.txt
@@ -5,17 +5,17 @@
 # Static Files and Media Storage
 # -------------------------------------
 django-storages==1.11.1
-boto3==1.17.54
+boto3==1.18.18
 
 # Caching
 # -------------------------------------
-django-redis==4.12.1
+django-redis==5.0.0
 hiredis==2.0.0
 
 {% if cookiecutter.newrelic == 'y' %}
 # Logging
 # -------------------------------------
-newrelic==6.2.0.156
+newrelic==6.8.0.163
 {% endif %}
 
 {%- if cookiecutter.add_django_auth_wall.lower() == 'y' %}


### PR DESCRIPTION
Note: Ansible not updated.

- Django updated to 3.1.x from 3.2.4 [changelog](https://docs.djangoproject.com/en/3.2/releases/3.2/)
- python-dotenv updated to 0.19.0 from 0.17.1 [changelog](https://github.com/theskumar/python-dotenv/blob/master/CHANGELOG.md)
- whitenoise updated to 5.3.0 from 5.2.0 [changelog](http://whitenoise.evans.io/en/stable/changelog.html)
- psycopg2-binary updated to 2.9.1 from 2.8.6 [changelog](https://www.psycopg.org/docs/news.html#what-s-new-in-psycopg-2-9)
- Pillow updated to 8.3.1 from 8.2.0 [changelog](https://pillow.readthedocs.io/en/stable/releasenotes/8.3.1.html)
- django-versatileimagefield updated to 2.1 from 2.0
- celery updated to 5.1.2 from 5.1.0
- mkdocs-material updated to 7.2.2 from 7.1.8
- iSort update to 5.9.3 [changelog](https://github.com/pycqa/isort/blob/main/CHANGELOG.md)
- pre-commit update to 2.14.0 [changelog](https://github.com/pre-commit/pre-commit/releases)
- boto3 updated to 1.18.18 from 1.17.94
- django-redis updated to 5.0.0 from 4.12.1 [changelog](https://pyup.io/changelogs/django-redis/#5.0.0)
- newrelic updated to 6.8.0.163 from 6.4.1.158
