### PR TITLE
Upgrade python libraries to thier latest patches

### DIFF
--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -27,7 +27,7 @@ pytz==2021.1
 # -------------------------------------
 psycopg2-binary==2.9.1
 
-Pillow==8.3.1
+Pillow==8.3.2
 django-extensions==3.1.3
 django-uuid-upload-path==1.0.0
 django-versatileimagefield==2.2

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -1,9 +1,10 @@
 -r common.txt
 
-# Documentation
+# Linting
 # -------------------------------------
 isort==5.9.3
 black==21.9b0
+flake8==3.9.2
 
 # Debugging
 # -------------------------------------

--- a/{{cookiecutter.github_repository}}/requirements/production.txt
+++ b/{{cookiecutter.github_repository}}/requirements/production.txt
@@ -5,7 +5,7 @@
 # Static Files and Media Storage
 # -------------------------------------
 django-storages==1.11.1
-boto3==1.18.18
+boto3==1.18.45
 
 # Caching
 # -------------------------------------
@@ -15,7 +15,7 @@ hiredis==2.0.0
 {% if cookiecutter.newrelic == 'y' %}
 # Logging
 # -------------------------------------
-newrelic==6.8.0.163
+newrelic==6.8.1.164
 {% endif %}
 
 {%- if cookiecutter.add_django_auth_wall.lower() == 'y' %}

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -247,6 +247,7 @@ SERVER_EMAIL = env("SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)
 # DATABASE CONFIGURATION
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
+# Using unix socket for postgres connection by default
 DATABASES = {"default": env.db("DATABASE_URL", default="postgres:///{{ cookiecutter.main_module }}")}
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
 DATABASES["default"]["CONN_MAX_AGE"] = 10

--- a/{{cookiecutter.github_repository}}/settings/common.py
+++ b/{{cookiecutter.github_repository}}/settings/common.py
@@ -247,9 +247,7 @@ SERVER_EMAIL = env("SERVER_EMAIL", default=DEFAULT_FROM_EMAIL)
 # DATABASE CONFIGURATION
 # ------------------------------------------------------------------------------
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
-DATABASES = {
-    "default": env.db("DATABASE_URL", default="postgres://localhost/{{ cookiecutter.main_module }}")
-}
+DATABASES = {"default": env.db("DATABASE_URL", default="postgres:///{{ cookiecutter.main_module }}")}
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
 DATABASES["default"]["CONN_MAX_AGE"] = 10
 {% if cookiecutter.postgis.lower() == "y" %}DATABASES["default"]["ENGINE"] = "django.contrib.gis.db.backends.postgis"{% endif %}


### PR DESCRIPTION
- Fixes Pillow [CVE-2021-23437](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-23437) and Django [timezone regression](https://docs.djangoproject.com/en/3.2/releases/3.2.7/)
- Use unix socket for postgres connection by default
- Add flake8 back(removed in 5648a36ff0369297ca1e044b32e494422c887008)