### PR TITLE
Source code analysis using Semgrep 

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,5 +19,6 @@
     , "add_django_auth_wall": "y"
     , "add_celery": "n"
     , "add_pre_commit": "y"
+    , "add_pre_commit_static_analysis": "n"
     , "pagination": ["LimitOffsetPagination", "CursorPagination"]
 }

--- a/{{cookiecutter.github_repository}}/.env.sample
+++ b/{{cookiecutter.github_repository}}/.env.sample
@@ -16,7 +16,7 @@
 
 # Databases
 # ==============================
-# DATABASE_URL=postgres://username:password@yourhost.com:5432/database_name
+# DATABASE_URL=postgres://<username>:<password>@yourhost.com:5432/database_name
 # REDIS_URL='redis://localhost:6379/'
 
 # File Storage

--- a/{{cookiecutter.github_repository}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.github_repository}}/.pre-commit-config.yaml
@@ -24,3 +24,22 @@ repos:
   rev: stable
   hooks:
     - id: black
+
+
+{%- if cookiecutter.add_pre_commit.lower() == 'y' and cookiecutter.add_pre_commit_static_analysis.lower() == 'y' %}
+
+- repo: https://github.com/returntocorp/semgrep
+  rev: v0.69.1
+  hooks:
+    - id: semgrep
+      args: [
+        '--config', 'p/python',
+        '--config', 'p/django',
+        '--config', 'p/secrets',
+        '--exclude', '.env.sample',
+        '--skip-unknown-extensions',
+        '--error',
+        '--quiet',
+        '--disable-metrics'
+      ]
+{%- endif %}

--- a/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/templates/404.html
+++ b/{{cookiecutter.github_repository}}/{{cookiecutter.main_module}}/templates/404.html
@@ -13,8 +13,9 @@
     <p>{% blocktrans %}The requested URL <code>{{ request_path }}</code> was not found on this server.{% endblocktrans %}</p>
 
     <style>#goog-wm ul{list-style: none; padding: 0; margin: 0;}</style>
+    {{ LANGUAGE_CODE|json_script:'lang-code' }}
     <script>
-      var GOOG_FIXURL_LANG = '{{ LANGUAGE_CODE }}';
+      var GOOG_FIXURL_LANG = JSON.parse(document.getElementById('lang-code').textContent);
       var GOOG_FIXURL_SITE = window.location.protocol + '//' + window.location.host;
     </script>
     <script src="https://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>


### PR DESCRIPTION

> Why was this change necessary?

I have been using django-init to kickstart most of my Django projects. In addition, I add a layer of security to my projects using semgrep - an easy-to-use static analysis tool. It is highly configurable and customizable. I think adding it here will enhance the security of downstream django-init users.

Just a way of saying - Thank you! :+1: 

> How does it address the problem?

The bare-bone django-init template is amazing and follows security best practices. The real pain starts when developers start developing their applications. The added rules (for [python](https://semgrep.dev/p/python), [django](https://semgrep.dev/p/django), and [secrets detection](https://semgrep.dev/p/secrets)) ensure that the downstream users also build secure and performant applications. Example -

- There is a rule to use the count method (over len) to determine the number of records - improves performance.
- There is a rule for avoiding insecure deserialization - improves security.
- There is a rule to avoid usage of template variables in script tags - this is addressed here - https://github.com/Fueled/django-init/commit/c2dbf11596704f0c80c8f2cca2e70f080747f651

The rules for secret detection ensure that sensitive keys do not get leaked through git history.

> Are there any side effects?

I have tested it a few times, none so far. 

PS: This feature is optional, and users can enable it along with pre-commit hooks. 
