### PR TITLE
Update packages: celery, ansible

### DIFF
--- a/{{cookiecutter.github_repository}}/provisioner/roles/common/defaults/main.yml
+++ b/{{cookiecutter.github_repository}}/provisioner/roles/common/defaults/main.yml
@@ -18,6 +18,7 @@ base_ubuntu:
       - python3.9
       - python3.9-dev
       - python-setuptools
+      - python3-venv
       - python3-pip
       - sysstat
       - vim

--- a/{{cookiecutter.github_repository}}/requirements/common.txt
+++ b/{{cookiecutter.github_repository}}/requirements/common.txt
@@ -48,7 +48,7 @@ raven==6.10.0
 
 # Async Tasks
 # -------------------------------------
-celery[redis]==5.2.1
+celery[redis]==5.2.2
 {%- endif %}
 
 # Auth Stuff

--- a/{{cookiecutter.github_repository}}/requirements/development.txt
+++ b/{{cookiecutter.github_repository}}/requirements/development.txt
@@ -27,7 +27,7 @@ bump2version==1.0.1
 
 {% if cookiecutter.add_ansible.lower() == 'y' %}# Deployment and Tasks
 # -------------------------------------
-ansible==2.10.7
+ansible==4.2.0
 {%- endif %}
 
 {%- if cookiecutter.add_pre_commit.lower() == 'y' %}


### PR DESCRIPTION
> Why was this change necessary?

Security vulnerabilities were found in celery 5.2.1 and ansible 2.2.1

> How does it address the problem?

Upgraded to celery 5.2.2 and ansible 4.2.0

> Are there any side effects?

None
