### PR TITLE
chore: upgrade black

### DIFF
--- a/{{cookiecutter.github_repository}}/pyproject.toml
+++ b/{{cookiecutter.github_repository}}/pyproject.toml
@@ -97,7 +97,7 @@ ansible = "~4.7"
 # Documentation
 # -------------------------------------
 isort = "^5.10"
-black = "~21.12b0"
+black = "~22.3.0"
 flake8 = "^4.0"
 
 # Debugging


### PR DESCRIPTION
> Why was this change necessary?

The current version of black doesn't work with click 8.1.0. https://black.readthedocs.io/en/stable/change_log.html#id7

> How does it address the problem?

Upgrades to the version that fixes the problem

> Are there any side effects?
No
