### PR TITLE
ci(github-actions): ensure poetry is installed lint action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-20.04
 
     services:
@@ -15,7 +14,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: hello_world
         ports:
-        - 5432:5432
+          - 5432:5432
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
@@ -23,19 +22,19 @@ jobs:
       DATABASE_URL: postgres://postgres:postgres@localhost:5432/hello_world
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
-        cache: 'pip'
-    - name: Install cookiecutter
-      run: |
-        python -m pip install --upgrade pip
-        pip3 install cookiecutter==1.7.3
-    - name: Install poetry
-      run: |
-        pip3 install poetry==1.1.12
-    - name: Run tests
-      run: |
-        ./run_test.sh
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+          cache: "pip"
+      - name: Install cookiecutter
+        run: |
+          python -m pip install --upgrade pip
+          pip3 install cookiecutter==1.7.3
+      - name: Install poetry
+        run: |
+          pip3 install poetry==1.2.0
+      - name: Run tests
+        run: |
+          ./run_test.sh

--- a/{{cookiecutter.github_repository}}/.github/workflows/main.yml
+++ b/{{cookiecutter.github_repository}}/.github/workflows/main.yml
@@ -42,6 +42,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip3 install -r requirements_dev.txt
+    - name: Install poetry
+      run: |
+        pip3 install poetry==1.2.0
     - name: Run tests
       run: |
         pytest --cov -v --tb=native


### PR DESCRIPTION
> Why was this change necessary?

`make lint` ran as part of CI/CD pipeline uses poetry to execute subsequent commands, but poetry is not installed -- which causes the pipeline to break.

> How does it address the problem?

It installs poetry first, before running `make lint` to ensure everything works in CI/CD flow.

> Are there any side effects?

None.
