### PR TITLE
fix(github-actions): Use poetry to install requirements & run tests

### DIFF
--- a/{{cookiecutter.github_repository}}/.github/workflows/main.yml
+++ b/{{cookiecutter.github_repository}}/.github/workflows/main.yml
@@ -38,16 +38,16 @@ jobs:
       with:
         python-version: '3.9'
         cache: 'pip'
-    - name: Install requirements
-      run: |
-        python -m pip install --upgrade pip
-        pip3 install -r requirements_dev.txt
     - name: Install poetry
       run: |
         pip3 install poetry==1.2.0
+    - name: Install requirements
+      run: |
+        python -m pip install --upgrade pip
+        poetry install --with dev
     - name: Run tests
       run: |
-        pytest --cov -v --tb=native
+        poetry run pytest --cov -v --tb=native
     - name: Linting
       run: |
         make lint

--- a/{{cookiecutter.github_repository}}/docs/backend/coding_rules.md
+++ b/{{cookiecutter.github_repository}}/docs/backend/coding_rules.md
@@ -15,7 +15,7 @@
 
 ## Django models
 
-* All model names in singular and CamelCase.
+* All model names in singular and PascalCase.
 * All models have a `Meta` with at least:
     - `verbose_name` and `verbose_name_plural`: unicode strings, lowercase, with spaces.
     - `ordering`: return a consistent order, using pk if no other unique field or combination exists.
@@ -24,12 +24,12 @@
 * All fields have explicit `blank` and `null` parameters. Use only those combinations, unless there a documented need of other thing:
 
     __Normal fields__ (IntegerField, DateField, ForeignKey, FileField...)
- 
+
         - (optional) `null = True`, `blank = True`
         - (required) `null = False`, `blank = False`
 
     __Text fields__ (CharField, TextField, URLField...)
- 
+
         - (optional) `null = False`, `blank = True`
         - (required) `null = False`, `blank = False`
 


### PR DESCRIPTION
> Why was this change necessary?

Currently github-actions uses legacy requirement file for dependency installation and not the updated poetry lock file. This legacy file can get out-of-date pretty quickly and a better way is to just use poetry to install dependencies and run tests.

> How does it address the problem?

Use poetry to install dependencies and run pytest.

> Are there any side effects?

None.
