### PR TITLE
docs(README): Update docs to drop legacy poetry command

### DIFF
--- a/{{cookiecutter.github_repository}}/README.md
+++ b/{{cookiecutter.github_repository}}/README.md
@@ -51,7 +51,7 @@ poetry export --without-hashes -f requirements.txt -o requirements.txt
 and
 
 ```bash
-poetry export --without-hashes -f requirements.txt -o requirements_dev.txt --dev
+poetry export --without-hashes -f requirements.txt -o requirements_dev.txt --with dev
 ```
 
 , respectively.


### PR DESCRIPTION
> Why was this change necessary?

The `--dev` flag in poetry is outdated. There is already a deprecation warning issued in poetry commands.

> How does it address the problem?

This updates the docs to reflect the poetry command with latest `--with dev` flag instead.

> Are there any side effects?

None.
