### PR TITLE
fix(pyproject.toml): Add dependencies for mkdocs

### DIFF
--- a/{{cookiecutter.github_repository}}/pyproject.toml
+++ b/{{cookiecutter.github_repository}}/pyproject.toml
@@ -37,6 +37,10 @@ drf-yasg = "^1.21"
 # Documentation
 # -------------------------------------
 mkdocs = "^1.2"
+pymdown-extensions = "^9.6"
+mkdocs-git-revision-date-localized-plugin = "^1.1.0"
+mkdocs-material = "^8.5.6"
+markdown-include = "^0.7.0"
 
 # Raven is the Sentry client
 # --------------------------


### PR DESCRIPTION
> Why was this change necessary?

There are couple of missing dependencies specifically for extensions related to mkdocs.

> How does it address the problem?

Add mkdocs dependencies to pyproject.toml directory for poetry to handle.

> Are there any side effects?

None.
