### PR TITLE
feat(docker): Use GDAL/postgis when postgis is enabled

### DIFF
--- a/{{cookiecutter.github_repository}}/compose/dev/django/Dockerfile
+++ b/{{cookiecutter.github_repository}}/compose/dev/django/Dockerfile
@@ -28,6 +28,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     # Versatile image field & pillow \
     libmagic1 \
     libmagic-dev \
+    {% if cookiecutter.add_postgis.lower() == "y" %}# GDAL postgres requirements
+    gdal-bin \
+    libgdal-dev \{% endif %}
     # cleaning up unused files
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     && rm -rf /var/lib/apt/lists/*

--- a/{{cookiecutter.github_repository}}/compose/dev/postgres/Dockerfile
+++ b/{{cookiecutter.github_repository}}/compose/dev/postgres/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:13
+{% if cookiecutter.add_postgis.lower() == "y" %}FROM postgis/postgis:13-3.3{% else %}FROM {{cookiecutter.add_postgis}}postgres:13{% endif %}
 
 COPY ./compose/dev/postgres/maintenance /usr/local/bin/maintenance
 RUN chmod +x /usr/local/bin/maintenance/*

--- a/{{cookiecutter.github_repository}}/compose/local/Dockerfile
+++ b/{{cookiecutter.github_repository}}/compose/local/Dockerfile
@@ -27,6 +27,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     # Versatile image field & pillow \
     libmagic1 \
     libmagic-dev \
+    {% if cookiecutter.add_postgis.lower() == "y" %}# GDAL postgres requirements
+    gdal-bin \
+    libgdal-dev \{% endif %}
     # cleaning up unused files
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
> Why was this change necessary?

If postgis is enabled, the docker setup does not work.

> How does it address the problem?

This PR enables use of postgis docker image for the database container & install GDAL for Django to communicate with the DB.

> Are there any side effects?

None.
