### PR TITLE
fix(compose): Use postgis protocol for connection

### DIFF
--- a/{{cookiecutter.github_repository}}/compose/dev/django/entrypoint
+++ b/{{cookiecutter.github_repository}}/compose/dev/django/entrypoint
@@ -12,7 +12,7 @@ if [ -z "${POSTGRES_USER}" ]; then
     base_postgres_image_default_user='postgres'
     export POSTGRES_USER="${base_postgres_image_default_user}"
 fi
-export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
+export DATABASE_URL="{% if cookiecutter.add_postgis.lower() == 'y' %}postgis{% else %}postgres{% endif %}://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 
 postgres_ready() {
 python << END

--- a/{{cookiecutter.github_repository}}/compose/local/entrypoint
+++ b/{{cookiecutter.github_repository}}/compose/local/entrypoint
@@ -12,7 +12,7 @@ if [ -z "${POSTGRES_USER}" ]; then
     base_postgres_image_default_user='postgres'
     export POSTGRES_USER="${base_postgres_image_default_user}"
 fi
-export DATABASE_URL="postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
+export DATABASE_URL="{% if cookiecutter.add_postgis.lower() == 'y' %}postgis{% else %}postgres{% endif %}://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
 
 postgres_ready() {
 python << END


### PR DESCRIPTION
> Why was this change necessary?

If postgis is enabled, the compose setup does not correctly use the postgis protocol for DB connection.

> How does it address the problem?

Depending on if `add_postgis` is chosen, the connection string will have corresponding protocol chosen.

> Are there any side effects?

None.