### PR TITLE
fix(Makefile): Update poetry export command to use --with option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ For compatibility, `requirements.txt` and `requirements_dev.txt` can be updated 
 
 ```bash
 poetry export -f requirements.txt -o requirements.txt
-poetry export -f requirements.txt -o requirements_dev.txt --dev
+poetry export -f requirements.txt -o requirements_dev.txt --with dev
 ```
 
 or

--- a/{{cookiecutter.github_repository}}/Makefile
+++ b/{{cookiecutter.github_repository}}/Makefile
@@ -51,7 +51,7 @@ regenerate:  ## Delete and create new database.
 .PHONY: regenerate
 
 generate_requirements:
-	poetry export -f requirements.txt -o requirements_dev.txt --dev
+	poetry export -f requirements.txt -o requirements_dev.txt --with dev
 	poetry export -f requirements.txt -o requirements.txt
 
 update_libs:  ## update libs + generate new lockfile & requirements


### PR DESCRIPTION
> Why was this change necessary?

The `--dev` option in `poetry export` command is deprecated. A warning is presented while using this option.

> How does it address the problem?

It updates the `poetry export` command to use the newer `--with` option.

> Are there any side effects?

None.
