### PR TITLE
fix(docker): Fixed an issue with the Postgres Docker image name

### DIFF
--- a/{{cookiecutter.github_repository}}/compose/dev/postgres/Dockerfile
+++ b/{{cookiecutter.github_repository}}/compose/dev/postgres/Dockerfile
@@ -1,4 +1,4 @@
-{% if cookiecutter.add_postgis.lower() == "y" %}FROM postgis/postgis:13-3.3{% else %}FROM {{cookiecutter.add_postgis}}postgres:13{% endif %}
+{% if cookiecutter.add_postgis.lower() == "y" %}FROM postgis/postgis:13-3.3{% else %}FROM postgres:13{% endif %}
 
 COPY ./compose/dev/postgres/maintenance /usr/local/bin/maintenance
 RUN chmod +x /usr/local/bin/maintenance/*


### PR DESCRIPTION
> Why was this change necessary?

When not choosing to add Postgis, the resulting dev Dockerfile for Postgres ends up prefixed with `n`. This results in a 404 when trying to download the Docker image.

What happens:
```dockerfile
FROM npostgres:13
```

Expected:
```dockerfile
FROM postgres:13
```

> How does it address the problem?

Removes the template prefix of `cookiecutter.add_postgis` value.

> Are there any side effects?

No
