### PR TITLE
Update production.py for redis issue

### DIFF
--- a/{{cookiecutter.github_repository}}/settings/production.py
+++ b/{{cookiecutter.github_repository}}/settings/production.py
@@ -145,7 +145,7 @@ CACHES = {
         "LOCATION": env("REDIS_URL", default="redis://localhost:6379/0"),
         "OPTIONS": {
             "CLIENT_CLASS": "django_redis.client.DefaultClient",
-            "PARSER_CLASS": "redis.connection.HiredisParser",
+            "PARSER_CLASS": "redis.connection._HiredisParser",
             "CONNECTION_POOL_CLASS": "redis.BlockingConnectionPool",
             "CONNECTION_POOL_CLASS_KWARGS": {
 {%- if cookiecutter.add_heroku.lower() == "y" %}


### PR DESCRIPTION


> Why was this change necessary?

I was facing an issue during the deployment of the application with `settings.production`. It is a problem of `redis.connection.HiredisParse`  it must be `redis.connection._HiredisParse`.

> How does it address the problem?

Not able to make the application live using  `settings.production`.

> Are there any side effects?

No, it is a fix of a library 
